### PR TITLE
Upgrade Artichoke to latest master

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,25 +27,31 @@ dependencies = [
 [[package]]
 name = "artichoke-backend"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d#5538436c73bd6acb6980d7c8896eca5e06093e9d"
+source = "git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9#7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9"
 dependencies = [
- "artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)",
- "artichoke-vfs 0.5.0-alpha (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)",
+ "artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)",
+ "artichoke-vfs 0.5.0-alpha (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)",
+ "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mruby-sys 2.0.1-18 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig 5.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "artichoke-core"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d#5538436c73bd6acb6980d7c8896eca5e06093e9d"
+source = "git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9#7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9"
 dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -53,7 +59,7 @@ dependencies = [
 [[package]]
 name = "artichoke-vfs"
 version = "0.5.0-alpha"
-source = "git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d#5538436c73bd6acb6980d7c8896eca5e06093e9d"
+source = "git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9#7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9"
 dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -121,27 +127,36 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.51.0"
+version = "0.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.28.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bitflags"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "bstr"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "bumpalo"
@@ -257,6 +272,11 @@ dependencies = [
 [[package]]
 name = "discard"
 version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "downcast"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -377,17 +397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mruby-sys"
-version = "2.0.1-18"
-source = "git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d#5538436c73bd6acb6980d7c8896eca5e06093e9d"
-dependencies = [
- "bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,8 +470,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "playground"
 version = "0.1.0"
 dependencies = [
- "artichoke-backend 0.1.0 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)",
- "artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)",
+ "artichoke-backend 0.1.0 (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)",
+ "artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdweb 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -585,6 +594,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +610,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "rustc-demangle"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rustc-hash"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc_version"
@@ -928,17 +953,18 @@ dependencies = [
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
-"checksum artichoke-backend 0.1.0 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)" = "<none>"
-"checksum artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)" = "<none>"
-"checksum artichoke-vfs 0.5.0-alpha (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)" = "<none>"
+"checksum artichoke-backend 0.1.0 (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)" = "<none>"
+"checksum artichoke-core 0.1.0 (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)" = "<none>"
+"checksum artichoke-vfs 0.5.0-alpha (git+https://github.com/artichoke/artichoke?rev=7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9)" = "<none>"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
 "checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base-x 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
 "checksum bindgen 0.50.0 (registry+https://github.com/rust-lang/crates.io-index)" = "65a913de3fa2fa95f2c593bb7e33b1be1ce1ce8a83f34b6bb02e6f01400b96cc"
-"checksum bindgen 0.51.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18270cdd7065ec045a6bb4bdcd5144d14a78b3aedb3bc5111e688773ac8b9ad0"
+"checksum bindgen 0.51.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebd71393f1ec0509b553aa012b9b58e81dadbdff7130bd3b8cba576e69b32f75"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
+"checksum bstr 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8d6c2c5b58ab920a4f5aeaaca34b4488074e8cc7596af94e6f8c6ff247c60245"
 "checksum bumpalo 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad807f2fc2bf185eeb98ff3a901bd46dc5ad58163d0fa4577ba0d25674d71708"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
@@ -953,6 +979,7 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum discard 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+"checksum downcast 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
@@ -969,7 +996,6 @@ dependencies = [
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
-"checksum mruby-sys 2.0.1-18 (git+https://github.com/artichoke/artichoke?rev=5538436c73bd6acb6980d7c8896eca5e06093e9d)" = "<none>"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
@@ -993,8 +1019,10 @@ dependencies = [
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
+"checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
+"checksum rustc-hash 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7540fc8b0c49f096ee9c961cda096467dce8084bec6bdca2fc83895fd9b28cb8"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c92464b447c0ee8c4fb3824ecc8383b81717b9f1e74ba2e72540aef7b9f82997"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -9,11 +9,12 @@ stdweb = "0.4.20"
 
 [dependencies.artichoke-backend]
 git = "https://github.com/artichoke/artichoke"
-rev = "5538436c73bd6acb6980d7c8896eca5e06093e9d"
+rev = "7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9"
+default-features = false
 
 [dependencies.artichoke-core]
 git = "https://github.com/artichoke/artichoke"
-rev = "5538436c73bd6acb6980d7c8896eca5e06093e9d"
+rev = "7ccb426ef8a7c4656ee0d24b3a31c5f65a9a08c9"
 
 [build-dependencies]
 rustc_version = "0.2.3"

--- a/scripts/activate-wasm-build-env.sh
+++ b/scripts/activate-wasm-build-env.sh
@@ -5,7 +5,25 @@ mrb_api=()
 
 # rg --no-line-number --no-filename -g '*.h' 'MRB_API .* (artichoke_[a-z0-9_]+?)\(.+\);' artichoke-backend/mruby-sys/include/ -r '$1' | sort | uniq
 # rg --no-line-number --no-filename -g '*.h' 'MRB_API .* (mrb_[a-z0-9_]+?)\(.+\);' artichoke-backend/mruby-sys/include/ -r '$1' | sort | uniq
-artichoke_exports=()
+artichoke_exports=(
+  '"_artichoke_value_to_ary"'
+  '"_artichoke_ary_new"'
+  '"_artichoke_ary_new_capa"'
+  '"_artichoke_ary_new_from_values"'
+  '"_artichoke_ary_splat"'
+  '"_artichoke_ary_clone"'
+  '"_artichoke_ary_ref"'
+  '"_artichoke_ary_pop"'
+  '"_artichoke_ary_shift"'
+  '"_artichoke_ary_unshift"'
+  '"_artichoke_ary_len"'
+  '"_artichoke_ary_concat"'
+  '"_artichoke_ary_push"'
+  '"_artichoke_ary_set"'
+  '"_artichoke_ary_check"'
+  '"_artichoke_gc_mark_ary"'
+  '"_artichoke_gc_mark_ary_size"'
+)
 
 playground_exports=(
   '"_main"'


### PR DESCRIPTION
This PR pulls in an updated artichoke dependency that includes the latest `Array` work.

This PR does compile but does not link at Wasm load time in the browser.

I think that the Rust -> C -> Rust chain of symbols is making the linker sad and causes the Artichoke `Array` C function to get dead code eliminated. See https://github.com/rust-lang/rust/issues/66026.

I have not yet tested this branch by disabling the `artichoke-array` default enabled feature on the `artichoke-backend` crate.