### PR TITLE
Add initial implementation of artichoke-web gem

### DIFF
--- a/playground/src/ffi.rs
+++ b/playground/src/ffi.rs
@@ -1,1 +1,81 @@
-#![cfg(target_arch = "wasm32")]
+use std::mem;
+
+use crate::interpreter::{Interp, State};
+
+#[no_mangle]
+pub fn artichoke_web_repl_init() -> u32 {
+    let mut state = Box::new(State::default());
+    let build = Interp::build_meta();
+    println!("{}", build);
+    state.heap.allocate(build);
+    Box::into_raw(state) as u32
+}
+
+#[no_mangle]
+pub fn artichoke_string_new(state: u32) -> u32 {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let mut state = unsafe { Box::from_raw(state as *mut State) };
+    let s = state.heap.allocate("".to_owned());
+    mem::forget(state);
+    s
+}
+
+#[no_mangle]
+pub fn artichoke_string_free(state: u32, ptr: u32) {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let mut state = unsafe { Box::from_raw(state as *mut State) };
+    state.heap.free(ptr);
+    mem::forget(state);
+}
+
+#[no_mangle]
+pub fn artichoke_string_getlen(state: u32, ptr: u32) -> u32 {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let state = unsafe { Box::from_raw(state as *mut State) };
+    let len = state.heap.string_getlen(ptr);
+    mem::forget(state);
+    len
+}
+
+#[no_mangle]
+pub fn artichoke_string_getch(state: u32, ptr: u32, idx: u32) -> u8 {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let state = unsafe { Box::from_raw(state as *mut State) };
+    let ch = state.heap.string_getch(ptr, idx);
+    mem::forget(state);
+    ch
+}
+
+#[no_mangle]
+pub fn artichoke_string_putch(state: u32, ptr: u32, ch: u8) {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let mut state = unsafe { Box::from_raw(state as *mut State) };
+    state.heap.string_putch(ptr, ch);
+    mem::forget(state);
+}
+
+#[no_mangle]
+pub fn artichoke_eval(state: u32, ptr: u32) -> u32 {
+    if state == 0 {
+        panic!("null pointer");
+    }
+    let mut state = unsafe { Box::from_raw(state as *mut State) };
+    let code = state.heap.string(ptr);
+    let interp = Interp::new();
+    let result = interp.eval(code);
+    let output = interp.captured_output();
+    let result = format!("{}{}", output, result);
+    let s = state.heap.allocate(result);
+    mem::forget(state);
+    s
+}

--- a/playground/src/interpreter.rs
+++ b/playground/src/interpreter.rs
@@ -1,0 +1,66 @@
+use artichoke_backend::eval::{Context, Eval};
+use artichoke_backend::Artichoke;
+use artichoke_core::value::Value;
+
+use crate::meta;
+use crate::string::Heap;
+use crate::web;
+
+#[derive(Default, Debug, Clone)]
+pub struct State {
+    pub heap: Heap,
+}
+
+pub struct Interp(Option<Artichoke>);
+
+impl Interp {
+    pub fn new() -> Self {
+        let interp = match artichoke_backend::interpreter() {
+            Ok(interp) => interp,
+            Err(err) => {
+                eprintln!("{:?}", err);
+                panic!("Could not initialize interpreter");
+            }
+        };
+        web::init(&interp).unwrap();
+        interp.0.borrow_mut().capture_output();
+        interp.push_context(Context::new(crate::REPL_FILENAME));
+        Self(Some(interp))
+    }
+
+    pub fn build_meta() -> String {
+        let interp = Self::new();
+        if let Some(ref interp) = interp.0 {
+            meta::build_info(&interp)
+        } else {
+            "Could not extract build meta".to_owned()
+        }
+    }
+
+    pub fn eval(&self, code: &[u8]) -> String {
+        if let Some(ref interp) = self.0 {
+            match interp.eval(code) {
+                Ok(value) => format!("=> {}", value.inspect()),
+                Err(err) => err.to_string(),
+            }
+        } else {
+            "".to_owned()
+        }
+    }
+
+    pub fn captured_output(&self) -> String {
+        if let Some(ref interp) = self.0 {
+            interp.0.borrow_mut().get_and_clear_captured_output()
+        } else {
+            "".to_owned()
+        }
+    }
+}
+
+impl Drop for Interp {
+    fn drop(&mut self) {
+        if let Some(interp) = self.0.take() {
+            interp.close();
+        }
+    }
+}

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/playground/src/main.rs
+++ b/playground/src/main.rs
@@ -2,153 +2,16 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(clippy::cast_possible_truncation, clippy::cast_lossless)]
 
-use artichoke_backend::eval::{Context, Eval};
-use artichoke_backend::Artichoke;
-use artichoke_core::value::Value;
-use std::mem;
-use std::panic::{self, AssertUnwindSafe};
+#[macro_use]
+extern crate artichoke_backend;
 
+pub mod ffi;
+mod interpreter;
 mod meta;
 mod string;
+mod web;
 
 const REPL_FILENAME: &[u8] = b"(playground)";
-
-#[derive(Default, Debug, Clone)]
-struct State {
-    heap: string::Heap,
-}
-
-struct Interp(Option<Artichoke>);
-
-impl Interp {
-    fn new() -> Self {
-        let interp = match artichoke_backend::interpreter() {
-            Ok(interp) => interp,
-            Err(err) => {
-                eprintln!("{:?}", err);
-                panic!("Could not initialize interpreter");
-            }
-        };
-        interp.0.borrow_mut().capture_output();
-        interp.push_context(Context::new(REPL_FILENAME));
-        Self(Some(interp))
-    }
-
-    fn build_meta() -> String {
-        let interp = Self::new();
-        if let Some(ref interp) = interp.0 {
-            meta::build_info(&interp)
-        } else {
-            "Could not extract build meta".to_owned()
-        }
-    }
-
-    fn eval(&self, code: &[u8]) -> String {
-        if let Some(ref interp) = self.0 {
-            match panic::catch_unwind(AssertUnwindSafe(|| interp.eval(code))) {
-                Ok(Ok(value)) => format!("=> {}", value.inspect()),
-                Ok(Err(err)) => err.to_string(),
-                Err(_) => "Panicked during eval".to_owned(),
-            }
-        } else {
-            "".to_owned()
-        }
-    }
-
-    fn captured_output(&self) -> String {
-        if let Some(ref interp) = self.0 {
-            interp.0.borrow_mut().get_and_clear_captured_output()
-        } else {
-            "".to_owned()
-        }
-    }
-}
-
-impl Drop for Interp {
-    fn drop(&mut self) {
-        if let Some(interp) = self.0.take() {
-            interp.close();
-        }
-    }
-}
-
-#[no_mangle]
-pub fn artichoke_web_repl_init() -> u32 {
-    let mut state = Box::new(State::default());
-    let build = Interp::build_meta();
-    println!("{}", build);
-    state.heap.allocate(build);
-    Box::into_raw(state) as u32
-}
-
-#[no_mangle]
-pub fn artichoke_string_new(state: u32) -> u32 {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let mut state = unsafe { Box::from_raw(state as *mut State) };
-    let s = state.heap.allocate("".to_owned());
-    mem::forget(state);
-    s
-}
-
-#[no_mangle]
-pub fn artichoke_string_free(state: u32, ptr: u32) {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let mut state = unsafe { Box::from_raw(state as *mut State) };
-    state.heap.free(ptr);
-    mem::forget(state);
-}
-
-#[no_mangle]
-pub fn artichoke_string_getlen(state: u32, ptr: u32) -> u32 {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let state = unsafe { Box::from_raw(state as *mut State) };
-    let len = state.heap.string_getlen(ptr);
-    mem::forget(state);
-    len
-}
-
-#[no_mangle]
-pub fn artichoke_string_getch(state: u32, ptr: u32, idx: u32) -> u8 {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let state = unsafe { Box::from_raw(state as *mut State) };
-    let ch = state.heap.string_getch(ptr, idx);
-    mem::forget(state);
-    ch
-}
-
-#[no_mangle]
-pub fn artichoke_string_putch(state: u32, ptr: u32, ch: u8) {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let mut state = unsafe { Box::from_raw(state as *mut State) };
-    state.heap.string_putch(ptr, ch);
-    mem::forget(state);
-}
-
-#[no_mangle]
-pub fn artichoke_eval(state: u32, ptr: u32) -> u32 {
-    if state == 0 {
-        panic!("null pointer");
-    }
-    let mut state = unsafe { Box::from_raw(state as *mut State) };
-    let code = state.heap.string(ptr);
-    let interp = Interp::new();
-    let result = interp.eval(code);
-    let output = interp.captured_output();
-    let result = format!("{}{}", output, result);
-    let s = state.heap.allocate(result);
-    mem::forget(state);
-    s
-}
 
 fn main() {
     stdweb::initialize();

--- a/playground/src/web/location.rs
+++ b/playground/src/web/location.rs
@@ -1,0 +1,33 @@
+use artichoke_backend::convert::{Convert, RustBackedValue};
+use artichoke_backend::extn::core::exception::{self, Fatal};
+use artichoke_backend::sys;
+use stdweb::web;
+
+pub struct Location(pub String);
+
+impl Location {
+    pub unsafe extern "C" fn hash(
+        mrb: *mut sys::mrb_state,
+        _slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = unwrap_interpreter!(mrb);
+        let result = web::window().location().map(|location| location.hash());
+        match result {
+            Some(Ok(value)) => interp.convert(value).inner(),
+            Some(Err(_)) => {
+                let exception = Box::new(Fatal::new(&interp, "SecurityError"));
+                exception::raise(interp, exception)
+            }
+            None => {
+                let exception = Box::new(Fatal::new(&interp, "No location"));
+                exception::raise(interp, exception)
+            }
+        }
+    }
+}
+
+impl RustBackedValue for Location {
+    fn ruby_type_name() -> &'static str {
+        "Artichoke::Web::Location"
+    }
+}

--- a/playground/src/web/mod.rs
+++ b/playground/src/web/mod.rs
@@ -1,0 +1,71 @@
+use artichoke_backend::def::{rust_data_free, ClassLike, Define, EnclosingRubyScope};
+use artichoke_backend::eval::Eval;
+use artichoke_backend::extn::core::artichoke::RArtichoke;
+use artichoke_backend::file::File;
+use artichoke_backend::load::LoadSources;
+use artichoke_backend::sys;
+use artichoke_backend::{Artichoke, ArtichokeError};
+
+mod location;
+mod window;
+
+use location::Location;
+use window::Window;
+
+pub fn init(interp: &Artichoke) -> Result<(), ArtichokeError> {
+    interp.def_file_for_type::<_, Web>("artichoke-web.rb")?;
+    interp.def_file_for_type::<_, Web>("artichoke/web.rb")?;
+    Ok(())
+}
+
+struct Web;
+
+impl File for Web {
+    fn require(interp: Artichoke) -> Result<(), ArtichokeError> {
+        let scope = interp
+            .0
+            .borrow_mut()
+            .module_spec::<RArtichoke>()
+            .map(EnclosingRubyScope::module)
+            .ok_or(ArtichokeError::New)?;
+        let web = interp.0.borrow_mut().def_module::<Self>("Web", Some(scope));
+        web.borrow().define(&interp)?;
+        let scope = interp
+            .0
+            .borrow_mut()
+            .module_spec::<Self>()
+            .map(EnclosingRubyScope::module)
+            .ok_or(ArtichokeError::New)?;
+        let window = interp
+            .0
+            .borrow_mut()
+            .def_module::<Window>("Window", Some(scope));
+        window
+            .borrow_mut()
+            .add_self_method("location", Window::location, sys::mrb_args_none());
+        window
+            .borrow_mut()
+            .add_method("location", Window::location, sys::mrb_args_none());
+        window.borrow().define(&interp)?;
+        let scope = interp
+            .0
+            .borrow_mut()
+            .module_spec::<Self>()
+            .map(EnclosingRubyScope::module)
+            .ok_or(ArtichokeError::New)?;
+        let location = interp.0.borrow_mut().def_class::<Location>(
+            "Location",
+            Some(scope),
+            Some(rust_data_free::<Location>),
+        );
+        location
+            .borrow_mut()
+            .add_self_method("hash", Location::hash, sys::mrb_args_none());
+        location
+            .borrow_mut()
+            .add_method("hash", Location::hash, sys::mrb_args_none());
+        location.borrow().define(&interp)?;
+        interp.eval(&include_bytes!("web.rb")[..])?;
+        Ok(())
+    }
+}

--- a/playground/src/web/web.rb
+++ b/playground/src/web/web.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Artichoke
+  module Web
+    module Window
+      extend self
+    end
+  end
+end

--- a/playground/src/web/window.rs
+++ b/playground/src/web/window.rs
@@ -1,0 +1,33 @@
+use artichoke_backend::convert::RustBackedValue;
+use artichoke_backend::extn::core::exception::{self, Fatal};
+use artichoke_backend::sys;
+
+use crate::web::location::Location;
+
+pub struct Window;
+
+impl Window {
+    pub unsafe extern "C" fn location(
+        mrb: *mut sys::mrb_state,
+        _slf: sys::mrb_value,
+    ) -> sys::mrb_value {
+        let interp = unwrap_interpreter!(mrb);
+        let result = Location(String::from("phantom")).try_into_ruby(&interp, None);
+        match result {
+            Ok(value) => value.inner(),
+            Err(err) => {
+                let exception = Box::new(Fatal::new(
+                    &interp,
+                    format!("Failed to serialize Rust Location into Ruby: {}", err),
+                ));
+                exception::raise(interp, exception)
+            }
+        }
+    }
+}
+
+impl RustBackedValue for Window {
+    fn ruby_type_name() -> &'static str {
+        "Artichoke::Web::Window"
+    }
+}


### PR DESCRIPTION
This gem exports `Artichoke::Web::Window` and `Artichoke::Web::Location`. Together, these enable the following program, a quine, on the playground:

```ruby
# frozen_string_literal: true

require 'uri'
require 'artichoke/web'

# This program is a quine built
# using Artichoke Ruby.
#
# The quine executes Rust, Ruby, and
# JavaScript with the URL as storage.

storage = Artichoke::Web::Window.location
program = storage.hash
deserialized = URI.decode(program)

puts deserialized
```

This PR reorganizes the crate into modules now that main has gotten too big.