### PR TITLE
Fix GitHub Actions README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Artichoke Playground
 
-[![GitHub Actions](https://github.com/artichoke/artichoke/workflows/CI/badge.svg)](https://github.com/artichoke/artichoke/actions)
+[![GitHub Actions](https://github.com/artichoke/playground/workflows/CI/badge.svg)](https://github.com/artichoke/playground/actions)
+[![GitHub Actions](https://github.com/artichoke/playground/workflows/Playground/badge.svg)](https://github.com/artichoke/playground/actions)
 [![Discord](https://img.shields.io/discord/607683947496734760)](https://discord.gg/QCe2tp2)
 [![Twitter](https://img.shields.io/twitter/follow/artichokeruby?label=Follow&style=social)](https://twitter.com/artichokeruby)
 


### PR DESCRIPTION
- Link to artichoke/playground's actions dashboard
- Use artichoke/playground CI badge
- Include Playground badge since that is the Wasm build and deploy