### PR TITLE
Add Google Analytics to Playground

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -142,18 +142,6 @@
                 >
                   artichoke-backend
                 </a>
-                <a
-                  class="dropdown-item"
-                  href="https://artichoke.github.io/artichoke/artichoke_vfs/"
-                >
-                  artichoke-vfs
-                </a>
-                <a
-                  class="dropdown-item"
-                  href="https://artichoke.github.io/artichoke/mruby_sys/"
-                >
-                  mruby-sys
-                </a>
                 <div class="dropdown-divider"></div>
                 <a
                   class="dropdown-item"

--- a/src/index.html
+++ b/src/index.html
@@ -3,13 +3,18 @@
   <head>
     <meta charset="utf-8" />
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-158900370-1"></script>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=UA-158900370-1"
+    ></script>
     <script>
       window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
 
-      gtag('config', 'UA-158900370-1');
+      gtag("config", "UA-158900370-1");
     </script>
     <meta
       name="viewport"

--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,15 @@
 <html>
   <head>
     <meta charset="utf-8" />
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-158900370-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-158900370-1');
+    </script>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"


### PR DESCRIPTION
Add Google Analytics tag manager to playground to measure usage.

Remove dead links in docs dropdown for crates that no longer exist upstream (mruby-sys and artichoke-vfs).