### PR TITLE
Ensure GitHub Actions with required checks run on external PRs

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -1,5 +1,13 @@
 name: Audit
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
 jobs:
   rust:
     name: Audit Rust Dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,13 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
 jobs:
   rust:
     name: Lint and format Rust

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -1,5 +1,13 @@
 name: Playground
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: "0 0 * * TUE"
 jobs:
   wasm:
     name: Build Playground


### PR DESCRIPTION
Only run workflows on pushes to master or PRs to master.
Also run workflows on  a schedule every Tuesday at midnight.