### PR TITLE
Remove vh units

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,9 @@ jobs:
           components: rustfmt, clippy
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang
@@ -57,12 +57,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
-
-      - name: Install bundler
-        run: gem install bundler
+          ruby-version: ".ruby-version"
 
       - name: Install gems
         run: bundle install

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -28,9 +28,9 @@ jobs:
           override: true
 
       - name: Install Ruby toolchain
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "2.6"
+          ruby-version: ".ruby-version"
 
       - name: Install Clang
         run: sudo apt install clang
@@ -56,7 +56,7 @@ jobs:
       - name: Compile
         run: cargo build --target wasm32-unknown-emscripten --release --verbose
         env:
-          RUSTFLAGS: "-C link-arg=-s -C link-arg=MODULARIZE=1"
+          RUSTFLAGS: "-D warnings -C link-arg=-s -C link-arg=MODULARIZE=1"
 
       - name: Webpack build
         run: npx webpack --mode production

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="h-100">
   <head>
     <meta charset="utf-8" />
     <meta
@@ -34,8 +34,8 @@
     <%= require('html-loader!./partials/favicons.html') %> <%=
     require('html-loader!./partials/google-analytics.html') %>
   </head>
-  <body>
-    <div id="wrapper" class="min-vh-100 vh-100 d-flex flex-column flex-grow">
+  <body class="h-100">
+    <div id="wrapper" class="h-100 d-flex flex-column flex-grow">
       <%= require('html-loader!./partials/nav.html') %>
 
       <div


### PR DESCRIPTION
Also clean up the build a bit:

- use ruby/setup-ruby with native `.ruby-version` detection
- add `-D warnings` to `RUSTFLAGS` when building the playground.