### PR TITLE
Fixup GitHub Actions build YAML and format YAML in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,8 +12,6 @@ jobs:
   rust:
     name: Lint and format Rust
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
@@ -50,8 +48,6 @@ jobs:
   ruby:
     name: Lint and format Ruby
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -70,8 +66,6 @@ jobs:
   js:
     name: Lint and format JS
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -94,8 +88,6 @@ jobs:
   text:
     name: Lint and format text
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -107,4 +99,4 @@ jobs:
         run: npx prettier --prose-wrap always --check '**/*.md'
 
       - name: Format YAML with prettier
-        run: npx prettier --prose-wrap always --check '**/*.yaml'
+        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'


### PR DESCRIPTION
strategy.fail-fast is not valid without a matrix
check YAML formatting in CI for yml extension