### PR TITLE
Cache playground build artifacts

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -9,18 +9,6 @@ on:
   schedule:
     - cron: "0 0 * * TUE"
 jobs:
-  rust:
-    name: Audit Rust Dependencies
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   js:
     name: Audit JS Dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,11 +30,8 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Clang
-        run: sudo apt install clang
-
       - name: Install Bison
-        run: sudo apt install bison
+        run: sudo apt-get install bison
 
       - name: Check formatting
         run: cargo fmt -- --check --color=auto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,9 +94,3 @@ jobs:
 
       - name: Lint and check formatting with prettier
         run: npx prettier --check '**/*'
-
-      - name: Format markdown with prettier
-        run: npx prettier --prose-wrap always --check '**/*.md'
-
-      - name: Format YAML with prettier
-        run: npx prettier --prose-wrap always --check '**/*.{yaml,yml}'

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -56,11 +56,8 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Clang
-        run: sudo apt install clang
-
       - name: Install Bison
-        run: sudo apt install bison
+        run: sudo apt-get install bison
 
       - name: Cache emsdk
         uses: actions/cache@v1

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -9,7 +9,7 @@ on:
   schedule:
     - cron: "0 0 * * TUE"
 jobs:
-  wasm:
+  build:
     name: Build Playground
     runs-on: ubuntu-latest
     env:
@@ -20,12 +20,36 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set toolchain versions
+        run: |
+          echo "::set-output name=rust::$(cat rust-toolchain)"
+          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+        id: toolchain_versions
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
           target: wasm32-unknown-emscripten
           profile: minimal
           override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: cargo-registry-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/git
+          key: cargo-index-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Cache cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: cargo-build-target-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1
@@ -38,14 +62,19 @@ jobs:
       - name: Install Bison
         run: sudo apt install bison
 
-      - name: Set emsdk version
-        run: echo "::set-output name=version::$(cat emscripten-toolchain)"
-        id: emsdk_toolchain
+      - name: Cache emsdk
+        uses: actions/cache@v1
+        id: cache
+        with:
+          path: "emsdk-cache"
+          key: emscripten-emsdk-${{ runner.os }}-emsdk-${{ steps.toolchain_versions.outputs.emscripten }}
 
       - name: Install Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v2
+        uses: mymindstorm/setup-emsdk@v4
         with:
-          version: ${{ steps.emsdk_toolchain.outputs.version }}
+          version: ${{ steps.toolchain_versions.outputs.emscripten }}
+          actions-cache-folder: "emsdk-cache"
+          no-cache: true
 
       - name: Verify emcc version
         run: emcc -v

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Webpack build
         run: npx webpack --mode production
 
-      - name: Deploy Docs
+      - name: Deploy Playground
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/master'
         with:

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,9 @@
+overrides:
+  # Always wrap markdown
+  - files: "*.md"
+    options:
+      proseWrap: always
+  # Preserve wrap for yaml as wrapping make some commands less readable
+  - files: "*.{yaml,yml}"
+    options:
+      proseWrap: preserve

--- a/package.json
+++ b/package.json
@@ -82,8 +82,6 @@
     "build": "RUSTFLAGS='-C link-arg=-s -C link-arg=MODULARIZE=1' cargo build --target wasm32-unknown-emscripten --release",
     "dev": "npx webpack-dev-server --mode production",
     "dev:open": "npx webpack-dev-server --mode production --open",
-    "fmt": "npx prettier --write '**/*'",
-    "fmt:md": "npx prettier --prose-wrap always --write '**/*.md'",
-    "fmt:yaml": "npx prettier --prose-wrap always --write '**/*.{yaml,yml}'"
+    "fmt": "npx prettier --write '**/*'"
   }
 }


### PR DESCRIPTION
Borrow these cache steps from the `async-std` CI workflow: https://github.com/async-rs/async-std/blob/370642ef3e41681b063f69796e427ebb2d51db68/.github/workflows/ci.yml#L32-L48

Turns out these are the recommended cache steps from actions/cache: https://github.com/actions/cache/blob/master/examples.md#rust---cargo

```yaml
- name: Cache cargo registry
  uses: actions/cache@v1
  with:
    path: ~/.cargo/registry
    key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
- name: Cache cargo index
  uses: actions/cache@v1
  with:
    path: ~/.cargo/git
    key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
- name: Cache cargo build
  uses: actions/cache@v1
  with:
    path: target
    key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
```

I've tweaked the cache keys to include the rustc version embedded in the `rust-toolchain` file.

Also added the caching steps recommended for the setup-emsdk action.

Additionally removed the explicit clang install step in several workflows since ubuntu base image includes clang by default.