### PR TITLE
Fix emsdk build setup failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --workspace --all-features
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -60,18 +60,17 @@ jobs:
         run: sudo apt-get install bison
 
       - name: Cache emsdk
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         id: cache
         with:
           path: "emsdk-cache"
           key: emscripten-emsdk-${{ runner.os }}-emsdk-${{ steps.toolchain_versions.outputs.emscripten }}
 
       - name: Install Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v4
+        uses: mymindstorm/setup-emsdk@v6
         with:
           version: ${{ steps.toolchain_versions.outputs.emscripten }}
           actions-cache-folder: "emsdk-cache"
-          no-cache: true
 
       - name: Verify emcc version
         run: emcc -v

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ namespace :lint do
     roots.each do |root|
       FileUtils.touch(root)
     end
-    sh 'cargo clippy'
+    sh 'cargo clippy --workspace --all-features'
   end
 
   desc 'Run RuboCop'


### PR DESCRIPTION
Upstream emsdk changed the setup scripts, which breaks v4 of the setup-emsdk action.

See https://github.com/mymindstorm/setup-emsdk/pull/7.