### PR TITLE
Add RuboCop GitHub error formatter to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         run: bundle install
 
       - name: Lint and check formatting with Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop --format github
 
   js:
     name: Lint and format JS

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'rake', require: false
-gem 'rubocop', require: false
-gem 'rubocop-rake', require: false
+gem 'rake', '>= 12.3.3', require: false
+gem 'rubocop', '~> 1.2', require: false
+gem 'rubocop-rake', '~> 0.5', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,9 +29,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  rake
-  rubocop
-  rubocop-rake
+  rake (>= 12.3.3)
+  rubocop (~> 1.2)
+  rubocop-rake (~> 0.5)
 
 BUNDLED WITH
    2.0.2


### PR DESCRIPTION
Introduced with bump to RuboCop 1.2.0 in #212.