### PR TITLE
Remove explicit bison installation in ubuntu Actions VMs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Bison
-        run: sudo apt-get install bison
-
       - name: Check formatting
         run: cargo fmt -- --check --color=auto
 

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -57,9 +57,6 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
-      - name: Install Bison
-        run: sudo apt-get install bison
-
       - name: Cache emsdk
         uses: actions/cache@v2
         id: cache


### PR DESCRIPTION
bison is in the base image by default.