### PR TITLE
Add production plugins and minification setting when --mode production is given to webpack

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -19,12 +19,12 @@ const plugins = [
   }),
 ];
 
-const config: webpack.ConfigurationFactory = (env) => {
+const config: webpack.ConfigurationFactory = (_env, argv) => {
   let cssLoader = "style-loader";
   let optimization: webpack.Options.Optimization = {
     minimize: false,
   };
-  if (env === "production") {
+  if (argv.mode === "production") {
     cssLoader = MiniCssExtractPlugin.loader;
     optimization = {
       minimize: true,


### PR DESCRIPTION
c81478a88d8600877c61864157ed7e4e121cd568 erroneously switched the production configuration to switch on `env` instead of `argv.mode` resulting in larger bundle size and non-extracted CSS.

Fixes #241.