### PR TITLE
Update artichoke repo markdown links to point to trunk branch

### DIFF
--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -30,7 +30,7 @@
         <li>
           <a
             class="text-muted"
-            href="https://github.com/artichoke/artichoke/blob/master/VISION.md"
+            href="https://github.com/artichoke/artichoke/blob/trunk/VISION.md"
           >
             Vision
           </a>


### PR DESCRIPTION
See https://github.com/artichoke/artichoke/pull/961, which transitions artichoke/artichoke's main branch to `trunk`.