### PR TITLE
Sync Rakefile improvements from artichoke/focaccia

### DIFF
--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -1,0 +1,16 @@
+{
+  "ignorePatterns": [
+    {
+      "pattern": "img.shields.io"
+    }
+  ],
+  "replacementPatterns": [],
+  "httpHeaders": [
+    {
+      "urls": ["https://crates.io"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
+}

--- a/Rakefile
+++ b/Rakefile
@@ -1,40 +1,123 @@
 # frozen_string_literal: true
 
-require 'fileutils'
+require 'open-uri'
+require 'shellwords'
+require 'rubocop/rake_task'
 
-task default: :lint
+task default: %i[format lint]
 
-desc 'Lint and format'
-task lint: %i[lint:format lint:clippy lint:rubocop lint:eslint]
+desc 'Lint sources'
+task lint: %i[lint:clippy lint:rubocop:auto_correct]
 
 namespace :lint do
-  desc 'Run Clippy'
+  RuboCop::RakeTask.new(:rubocop)
+
+  desc 'Lint JavaScript and TypeScript sources with eslint'
+  task eslint: :deps do
+    sh 'npm ci'
+    sh 'npx eslint --fix .'
+  end
+
+  desc 'Lint Rust sources with Clippy'
   task :clippy do
-    roots = Dir.glob('**/{build,lib,main}.rs')
-    roots.each do |root|
+    FileList['**/{build,lib,main}.rs'].each do |root|
       FileUtils.touch(root)
     end
     sh 'cargo clippy --workspace --all-features'
   end
 
-  desc 'Run RuboCop'
-  task :rubocop do
-    sh 'rubocop -a'
+  desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'
+  task :'clippy:restriction' do
+    FileList['**/{build,lib,main}.rs'].each do |root|
+      FileUtils.touch(root)
+    end
+    lints = [
+      'clippy::dbg_macro',
+      'clippy::get_unwrap',
+      'clippy::indexing_slicing',
+      'clippy::panic',
+      'clippy::print_stdout',
+      'clippy::expect_used',
+      'clippy::unwrap_used',
+      'clippy::todo',
+      'clippy::unimplemented',
+      'clippy::unreachable'
+    ]
+    command = ['cargo', 'clippy', '--'] + lints.flat_map { |lint| ['-W', lint] }
+    sh command.shelljoin
   end
+end
 
-  desc 'Format sources'
-  task format: :deps do
+desc 'Format sources'
+task format: %i[format:rust format:text]
+
+namespace :format do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
     sh 'cargo fmt -- --color=auto'
-    sh 'npm run fmt'
   end
 
-  desc 'Run ESlint'
-  task eslint: :deps do
-    sh 'npx eslint --fix .'
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
+    sh "npx prettier --write '**/*'"
+  end
+end
+
+desc 'Format sources'
+task fmt: %i[fmt:rust fmt:text]
+
+namespace :fmt do
+  desc 'Format Rust sources with rustfmt'
+  task :rust do
+    sh 'cargo fmt -- --color=auto'
   end
 
-  desc 'Install linting dependencies'
-  task :deps do
-    sh 'npm ci'
+  desc 'Format text, YAML, and Markdown sources with prettier'
+  task :text do
+    sh "npx prettier --write '**/*'"
+  end
+end
+
+desc 'Build Rust workspace'
+task :build do
+  sh 'cargo build --workspace'
+end
+
+desc 'Generate Rust API documentation'
+task :doc do
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
+  sh 'rustup run --install nightly cargo doc --workspace'
+end
+
+desc 'Generate Rust API documentation and open it in a web browser'
+task :'doc:open' do
+  ENV['RUSTFLAGS'] = '-D warnings'
+  ENV['RUSTDOCFLAGS'] = '-D warnings --cfg docsrs'
+  sh 'rustup run --install nightly cargo doc --workspace --open'
+end
+
+desc 'Run Playground unit tests'
+task :test do
+  sh 'cargo test --workspace'
+end
+
+namespace :release do
+  link_check_files = FileList.new('**/*.md') do |f|
+    f.exclude('emsdk/**/*')
+    f.exclude('node_modules/**/*')
+    f.exclude('**/target/**/*')
+    f.exclude('**/vendor/**/*')
+    f.include('*.md')
+    f.include('**/vendor/*.md')
+  end
+
+  link_check_files.sort.uniq.each do |markdown|
+    desc 'Check for broken links in markdown files'
+    task markdown_link_check: markdown do
+      command = ['npx', 'markdown-link-check', '--config', '.github/markdown-link-check.json', markdown]
+      sh command.shelljoin
+      sleep(rand(1..5))
+    end
   end
 end


### PR DESCRIPTION
- Split format and lint into separate task groups.
- Set default task to `format` and `lint`.
- Use `RuboCop::RakeTask` to get `rubocop` and `rubcop:auto_correct`
  tasks.
- Use `FileList` instead of `Dir::glob` for globs to activate `clippy`.
- Add unenforced `clippy:restriction` lint pass.
- Split `rustfmt` and `prettier` format tasks in two.
- Add `fmt` task group for convenience that is a duplicate of the
  `format` task group.
- Add `build` task.
- Add `doc` and `doc:open` tasks.
- Add `test` task that invokes `cargo test --workspace`.
- Add `release` task group with markdown link well-formedness checking.
- Add `markdown-link-check` config file.