### PR TITLE
Construct GitHub Actions cache keys with hash of Cargo.lock

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -38,19 +38,19 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.cargo/registry
-          key: cargo-registry-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: cargo-registry-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
           path: ~/.cargo/git
-          key: cargo-index-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: cargo-index-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache cargo build
         uses: actions/cache@v1
         with:
           path: target
-          key: cargo-build-target-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: cargo-build-target-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
The existing cache key configuration was cargo culted from `async-std`
which is a library and doesn't check in its `Cargo.lock`. This mostly
worked because the playground primarily updates its deps when
`artichoke` has its git revision bumped.

`Cargo.lock` encodes the current state of dependencies, so hashing this
is sufficient to encode the current cache state.