### PR TITLE
Use Swatinem/rust-cache GitHub Action for caching Rust build output

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,6 +55,8 @@ jobs:
         with:
           ruby-version: ".ruby-version"
 
+      - uses: Swatinem/rust-cache@v1
+
       - name: Check formatting
         run: cargo fmt -- --check --color=auto
 

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -34,23 +34,7 @@ jobs:
           profile: minimal
           override: true
 
-      - name: Cache cargo registry
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/registry
-          key: cargo-registry-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v1
-        with:
-          path: ~/.cargo/git
-          key: cargo-index-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v1
-        with:
-          path: target
-          key: cargo-build-target-${{ runner.os }}-rust-${{ steps.toolchain_versions.outputs.rust }}-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v1
 
       - name: Install Ruby toolchain
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Improvements over #298 and #78.