### PR TITLE
Remove node typescript types

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -68,9 +68,6 @@ jobs:
       - name: Move Wasm artifacts
         run: cp target/wasm32-unknown-emscripten/release/playground.{js,wasm} src/wasm/
 
-      - name: Compile with TypeScript
-        run: npx tsc --extendedDiagnostics --listFiles --listEmittedFiles
-
       - name: Webpack build
         run: npx webpack --mode production
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@artichokeruby/logo": "^0.8.0",
     "@hyperbola/svgo-loader": "^0.1.2",
     "@types/gtag.js": "0.0.4",
-    "@types/node": "^14.14.30",
     "@typescript-eslint/eslint-plugin": "^4.15.1",
     "@typescript-eslint/parser": "^4.15.1",
     "css-loader": "^5.0.2",


### PR DESCRIPTION
These types were used when webpack.config.js was typescript, which it no longer is.

Also remove a duplicate tsc compile step when building playground static assets which erroneously puts a main.ts in the github-pages HEAD.