### PR TITLE
Factor out unwieldy npm script to a Ruby script

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -61,12 +61,7 @@ jobs:
         run: npm ci
 
       - name: Compile
-        run: cargo build --target wasm32-unknown-emscripten --release --verbose
-        env:
-          RUSTFLAGS: "-D warnings -C link-arg=-s -C link-arg=MODULARIZE=1 -C link-arg=-s -C link-arg=WASM=1 -C link-arg=-s -C link-arg=ENVIRONMENT=web -C link-arg=-s -C link-arg=SUPPORT_LONGJMP=1"
-
-      - name: Move Wasm artifacts
-        run: cp target/wasm32-unknown-emscripten/release/playground.{js,wasm} src/wasm/
+        run: ruby scripts/build-wasm.rb --release --verbose
 
       - name: Webpack build
         run: npx webpack --mode production

--- a/package.json
+++ b/package.json
@@ -74,8 +74,8 @@
     ]
   },
   "scripts": {
-    "build": "RUSTFLAGS='-C link-arg=-s -C link-arg=MODULARIZE=1 -C link-arg=-s -C link-arg=WASM=1 -C link-arg=-s -C link-arg=ENVIRONMENT=web -C link-arg=-s -C link-arg=SUPPORT_LONGJMP=1' cargo build --target wasm32-unknown-emscripten; mv target/wasm32-unknown-emscripten/debug/playground.{js,wasm} src/wasm/",
-    "build:release": "RUSTFLAGS='-C link-arg=-s -C link-arg=MODULARIZE=1 -C link-arg=-s -C link-arg=WASM=1 -C link-arg=-s -C link-arg=ENVIRONMENT=web -C link-arg=-s -C link-arg=SUPPORT_LONGJMP=1' cargo build --target wasm32-unknown-emscripten --release; mv target/wasm32-unknown-emscripten/release/playground.{js,wasm} src/wasm/",
+    "build": "ruby scripts/build-wasm.rb",
+    "build:release": "ruby scripts/build-wasm.rb --release",
     "dev": "webpack serve --mode development",
     "dev:open": "webpack serve --mode development --open",
     "dev:production": "wepack serve --mode production",

--- a/scripts/build-wasm.rb
+++ b/scripts/build-wasm.rb
@@ -1,0 +1,68 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'fileutils'
+
+RUSTFLAGS = %w[
+  -C
+  link-arg=-s
+  -C
+  link-arg=MODULARIZE=1
+  -C
+  link-arg=-s
+  -C
+  link-arg=WASM=1
+  -C
+  link-arg=-s
+  -C
+  link-arg=ENVIRONMENT=web
+  -C
+  link-arg=-s
+  -C
+  link-arg=SUPPORT_LONGJMP=1
+].freeze
+
+def build_debug
+  ENV['RUSTFLAGS'] = RUSTFLAGS.join(' ')
+
+  `cargo build --target wasm32-unknown-emscripten`
+
+  FileUtils.mv(
+    ['target/wasm32-unknown-emscripten/debug/playground.js', 'target/wasm32-unknown-emscripten/debug/playground.wasm'],
+    'src/wasm/'
+  )
+rescue ArgumentError, Errno::ENOENT
+  # pass
+end
+
+def build_release(verbose: false)
+  ENV['RUSTFLAGS'] = RUSTFLAGS.join(' ')
+
+  if verbose
+    `cargo build --target wasm32-unknown-emscripten --release --verbose`
+  else
+    `cargo build --target wasm32-unknown-emscripten --release`
+  end
+
+  FileUtils.mv(
+    ['target/wasm32-unknown-emscripten/release/playground.js',
+     'target/wasm32-unknown-emscripten/release/playground.wasm'],
+    'src/wasm/'
+  )
+rescue ArgumentError, Errno::ENOENT
+  # pass
+end
+
+def main
+  if ARGV == ['--release', '--verbose'] || ARGV == ['--verbose', '--release']
+    build_release(verbose: true)
+  elsif ARGV == ['--release']
+    build_release
+  elsif ARGV.empty?
+    build_debug
+  else
+    warn "Usage: #{$PROGRAM_NAME} [ --release ]"
+  end
+end
+
+main if __FILE__ == $PROGRAM_NAME


### PR DESCRIPTION
For building Wasm artifacts in debug, release, and CI.

This change unifies dev builds and CI builds.