### PR TITLE
Upgrade logo and branding to V2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@artichokeruby/logo": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@artichokeruby/logo/-/logo-0.8.0.tgz",
-      "integrity": "sha512-wlMqls3dtuxi70R+gxkQtcdJj5ym7DpCP7Syta36XgWXFUQN74Q5P1gAqJFrY6GuMjBnFDtDUvXUvIZKPD9gWg==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@artichokeruby/logo/-/logo-0.9.1.tgz",
+      "integrity": "sha512-oyrR08BGH/r+VBffg9Z61Vq3rwBLeVzE9oRgBiV5u/6/74Ys/85muROM6nHTDKMk/BniR+4YL0Yi2S/YCbs8jw==",
       "dev": true
     },
     "@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "monaco-editor": "^0.22.3"
   },
   "devDependencies": {
-    "@artichokeruby/logo": "^0.8.0",
+    "@artichokeruby/logo": "^0.9.1",
     "@hyperbola/svgo-loader": "^0.2.1",
     "@types/gtag.js": "0.0.4",
     "@typescript-eslint/eslint-plugin": "^4.16.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,10 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import * as monaco from "monaco-editor";
 
 // Assets with well-known filenames
+import "@artichokeruby/logo/img/artichoke-logo.png";
+import "@artichokeruby/logo/img/artichoke-logo.svg";
+import "@artichokeruby/logo/img/artichoke-logo-inverted.png";
+import "@artichokeruby/logo/img/artichoke-logo-inverted.svg";
 import "@artichokeruby/logo/img/playground.png";
 import "@artichokeruby/logo/img/playground-social-logo.png";
 import "./assets/robots.txt";

--- a/src/partials/favicons.html
+++ b/src/partials/favicons.html
@@ -1,47 +1,58 @@
-<!-- favicons -->
+<!-- generics -->
+<link
+  rel="icon"
+  href="~@artichokeruby/logo/favicons/favicon-32x32.png"
+  sizes="32x32"
+/>
+<link
+  rel="icon"
+  href="~@artichokeruby/logo/favicons/favicon-128x128.png"
+  sizes="128x128"
+/>
+<link
+  rel="icon"
+  href="~@artichokeruby/logo/favicons/favicon-192x192.png"
+  sizes="192x192"
+/>
+
+<!-- Android -->
+<link
+  rel="shortcut icon"
+  sizes="196x196"
+  href="~@artichokeruby/logo/favicons/favicon-196x196.png"
+/>
+
+<!-- iOS -->
 <link
   rel="apple-touch-icon"
+  href="~@artichokeruby/logo/favicons/favicon-152x152.png"
+  sizes="152x152"
+/>
+<link
+  rel="apple-touch-icon"
+  href="~@artichokeruby/logo/favicons/favicon-180x180.png"
   sizes="180x180"
-  href="~@artichokeruby/logo/favicons/apple-touch-icon.png"
 />
-<link
-  rel="icon"
-  type="image/png"
-  sizes="32x32"
-  href="~@artichokeruby/logo/favicons/favicon-32x32.png"
-/>
-<link
-  rel="icon"
-  type="image/png"
-  sizes="16x16"
-  href="~@artichokeruby/logo/favicons/favicon-16x16.png"
-/>
-<link
-  rel="icon"
-  type="image/png"
-  sizes="192x192"
-  href="~@artichokeruby/logo/favicons/android-chrome-192x192.png"
-/>
-<link
-  rel="icon"
-  type="image/png"
-  sizes="512x512"
-  href="~@artichokeruby/logo/favicons/android-chrome-512x512.png"
-/>
-<link rel="manifest" href="~@artichokeruby/logo/favicons/site.webmanifest" />
+
+<!-- Safari pinned tab icon -->
 <link
   rel="mask-icon"
   href="~@artichokeruby/logo/favicons/safari-pinned-tab.svg"
-  color="#b91d47"
+  color="black"
 />
-<link rel="shortcut icon" href="~@artichokeruby/logo/favicons/favicon.ico" />
-<meta
-  name="msapplication-config"
-  content="~@artichokeruby/logo/favicons/browserconfig.xml"
-/>
-<meta name="msapplication-tilecolor" content="#b91d47" />
+
+<!-- Windows 8 IE 10 -->
+<meta name="msapplication-tilecolor" content="#ffffff" />
 <meta
   name="msapplication-tileimage"
   content="~@artichokeruby/logo/favicons/mstile-150x150.png"
 />
-<meta name="theme-color" content="#ffffff" />
+
+<!-- Windows 8.1 + IE11 and above -->
+<meta
+  name="msapplication-config"
+  content="~@artichokeruby/logo/favicons/browserconfig.xml"
+/>
+
+<!-- Progressive webapp -->
+<link rel="manifest" href="~@artichokeruby/logo/favicons/site.webmanifest" />

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -1,24 +1,5 @@
 <footer class="container py-5">
   <div class="row">
-    <div class="col-12">
-      <a class="py-2" href="#" aria-label="Artichoke Ruby">
-        <img
-          width="24"
-          height="24"
-          title="Artichoke Ruby"
-          alt="Artichoke Ruby logo"
-          src="~@artichokeruby/logo/optimized/artichoke-logo.svg"
-        />
-      </a>
-      <small class="d-block mb-3 text-muted">
-        &copy; 2019-2021 | Playground powered by a
-        <a href="https://github.com/artichoke/playground">
-          WebAssembly build
-        </a>
-        of
-        <a href="https://github.com/artichoke/artichoke">Artichoke Ruby</a>.
-      </small>
-    </div>
     <div class="col-xs-12 col-md-4">
       <h5>Project</h5>
       <ul class="list-unstyled text-small">
@@ -43,7 +24,7 @@
         <li>
           <a
             class="text-muted"
-            href="https://github.com/artichoke/playground/issues/new"
+            href="https://github.com/artichoke/artichoke/issues/new"
           >
             File a bug
           </a>
@@ -92,6 +73,26 @@
           </a>
         </li>
       </ul>
+    </div>
+    <hr class="my-0" />
+    <div class="col-12 px-0">
+      <a href="/" aria-label="Artichoke Ruby">
+        <img
+          height="64"
+          title="Artichoke Ruby"
+          alt="Artichoke Ruby logo"
+          src="~@artichokeruby/logo/optimized/wordmark-black.svg"
+        />
+      </a>
+      <br />
+      <small class="d-block mb-3 text-muted">
+        Playground powered by a
+        <a href="https://github.com/artichoke/playground">
+          WebAssembly build
+        </a>
+        of
+        <a href="https://github.com/artichoke/artichoke">Artichoke Ruby</a>.
+      </small>
     </div>
   </div>
 </footer>

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -3,11 +3,10 @@
     <a class="navbar-brand" href="/" aria-label="Artichoke Ruby">
       <img
         class="float-start"
-        width="40"
         height="40"
         title="Artichoke Ruby"
         alt="Artichoke Ruby logo"
-        src="~@artichokeruby/logo/optimized/artichoke-logo.svg"
+        src="~@artichokeruby/logo/optimized/nav-white.svg"
       />
     </a>
     <button


### PR DESCRIPTION
This is the playground half of the branding updates first landed on the project website in https://github.com/artichoke/www.artichokeruby.org/pull/263.

## Screenshots

### Header

<img width="1480" alt="Screen Shot 2021-03-02 at 8 06 02 PM" src="https://user-images.githubusercontent.com/860434/109751197-cd9d1e80-7b92-11eb-8b28-c30c7b061bfc.png">

### Footer

<img width="1480" alt="Screen Shot 2021-03-02 at 8 06 17 PM" src="https://user-images.githubusercontent.com/860434/109751213-d55cc300-7b92-11eb-9893-745d43aa9129.png">
