### PR TITLE
Update Rakefile and RuboCop configuration to work on Windows machines

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,6 +9,14 @@ AllCops:
     - "**/node_modules/**/*"
     - "**/target/**/*"
     - "**/vendor/**/*"
+Layout/EndOfLine:
+  EnforcedStyle: lf
+Layout/LineLength:
+  Enabled: true
+  Exclude:
+    - "**/Rakefile"
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
 Metrics:
   Enabled: false
 Style/Documentation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,14 @@ rake test                         # Run Playground unit tests
 To lint Ruby sources, the playground uses [RuboCop]. RuboCop runs as part of the
 `lint:all` task. You can run only RuboCop by invoking the `lint:rubocop` task.
 
+### Python
+
+Python is required for installing [emsdk], which is used for building on
+WebAssembly targets.
+
+On Windows, install the latest Python release from:
+<https://www.python.org/downloads/>.
+
 ### Node.js
 
 Node.js is required for bundling the webapp with webpack and testing in
@@ -253,6 +261,7 @@ the playground, update this hash in [`Cargo.toml`](playground/Cargo.toml).
 [rbenv]: https://github.com/rbenv/rbenv
 [ruby-build]: https://github.com/rbenv/ruby-build
 [rubocop]: https://github.com/rubocop-hq/rubocop
+[emsdk]: https://emscripten.org/docs/tools_reference/emsdk.html
 [prettier]: https://prettier.io/
 [node.js]: https://nodejs.org/en/download/package-manager/
 [rust book chapter on testing]:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,12 @@ brew install rustup-init
 rustup-init
 ```
 
+On Windows, you can install rustup from the official site and follow the
+prompts: <https://rustup.rs/>. This requires a download of Visual Studio (the
+[Community Edition][vs-community] is sufficient) and several C++ packages
+selected through the VS component installer. (I'm not sure which packages are
+required; I selected them all.)
+
 Once you have rustup, you can install the Rust toolchain needed to compile the
 playground.
 
@@ -72,6 +78,16 @@ cargo clippy --all-targets --all-features
 
 ### C Toolchain
 
+Some artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
+FFI bindings and the [`onig`] crate, build C static libraries and require a C
+compiler.
+
+Artichoke specifically requires clang. WebAssembly targets require clang-8 or
+newer.
+
+On Windows, install the latest LLVM distribution from GitHub and add LLVM to
+your PATH: <https://github.com/llvm/llvm-project/releases>.
+
 #### `cc` Crate
 
 Artichoke and some of its dependencies use the Rust [`cc` crate] to build. `cc`
@@ -84,7 +100,6 @@ To build the Artichoke mruby backend, you will need a C compiler toolchain. By
 default, mruby requires the following to compile:
 
 - clang
-- bison
 - ar
 
 You can override the requirement for clang by setting the `CC` and `LD`
@@ -229,6 +244,7 @@ the playground, update this hash in [`Cargo.toml`](playground/Cargo.toml).
 [join artichoke's public discord server]: https://discord.gg/QCe2tp2
 [rustup]: https://rustup.rs/
 [homebrew]: https://docs.brew.sh/Installation
+[vs-community]: https://visualstudio.microsoft.com/vs/community/
 [`cc` crate]: https://crates.io/crates/cc
 [platform-dependent c compiler]:
   https://github.com/alexcrichton/cc-rs#compile-time-requirements

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 
@@ -74,7 +74,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh "npx prettier --write '**/*'"
+    sh 'npx prettier --write "**/*"'
   end
 end
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "dev:open": "webpack serve --mode development --open",
     "dev:production": "wepack serve --mode production",
     "dev:production:open": "webpack serve --mode production --open",
-    "fmt": "npx prettier --write '**/*'",
+    "fmt": "npx prettier --write \"**/*\"",
     "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "npx eslint . --ext .js,.jsx,.ts,.tsx --fix"
   }


### PR DESCRIPTION
- Force line feed endings in RuboCop configuration instead of the default "native" endings.
- Fix quotes for prettier globs so they work in Windows Terminal and PowerShell.
- Add docs on how to set up a toolchain on Windows to `BUILD.md`.