### PR TITLE
Update devtools Rakefile and CI clippy invocation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,7 +69,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features
+          args: --workspace --all-features --all-targets
 
   ruby:
     name: Lint and format Ruby

--- a/Rakefile
+++ b/Rakefile
@@ -20,10 +20,7 @@ namespace :lint do
 
   desc 'Lint Rust sources with Clippy'
   task :clippy do
-    FileList['**/{build,lib,main}.rs'].each do |root|
-      FileUtils.touch(root)
-    end
-    sh 'cargo clippy --workspace --all-features'
+    sh 'cargo clippy --workspace --all-features --all-targets'
   end
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'


### PR DESCRIPTION
- Pass --all-targets to match CI
- Remove touch command for entrypoints which was made unneccesary in Rust 1.52.0