### PR TITLE
Improve the quality of the `emscripten_set_main_loop` abstraction

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Set toolchain versions
+        run: |
+          echo "::set-output name=rust::$(cat rust-toolchain)"
+          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+        id: toolchain_versions
+
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -61,7 +67,21 @@ jobs:
           ruby-version: ".ruby-version"
           bundler-cache: true
 
-      - uses: Swatinem/rust-cache@v1
+      - name: Cache emsdk
+        uses: actions/cache@v2
+        id: cache
+        with:
+          path: "emsdk-cache"
+          key: emscripten-emsdk-${{ runner.os }}-emsdk-${{ steps.toolchain_versions.outputs.emscripten }}-clippy
+
+      - name: Install Emscripten toolchain
+        uses: mymindstorm/setup-emsdk@v10
+        with:
+          version: ${{ steps.toolchain_versions.outputs.emscripten }}
+          actions-cache-folder: "emsdk-cache"
+
+      - name: Verify emcc version
+        run: emcc -v
 
       - name: Check formatting
         run: cargo fmt -- --check --color=auto

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
         with:
           profile: minimal
           components: rustfmt, clippy
+          target: wasm32-unknown-emscripten
 
       - uses: Swatinem/rust-cache@v1
 
@@ -70,6 +71,12 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --workspace --all-features --all-targets
+
+      - name: Lint with Clippy on emscripten target
+        uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --workspace --all-features --all-targets --target wasm32-unknown-emscripten
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -50,7 +50,7 @@ jobs:
           key: emscripten-emsdk-${{ runner.os }}-emsdk-${{ steps.toolchain_versions.outputs.emscripten }}
 
       - name: Install Emscripten toolchain
-        uses: mymindstorm/setup-emsdk@v7
+        uses: mymindstorm/setup-emsdk@v10
         with:
           version: ${{ steps.toolchain_versions.outputs.emscripten }}
           actions-cache-folder: "emsdk-cache"

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ namespace :lint do
   desc 'Lint Rust sources with Clippy'
   task :clippy do
     sh 'cargo clippy --workspace --all-features --all-targets'
+    sh 'cargo clippy --workspace --all-features --all-targets --target wasm32-unknown-emscripten'
   end
 
   desc 'Lint Rust sources with Clippy restriction pass (unenforced lints)'

--- a/playground/src/emscripten.rs
+++ b/playground/src/emscripten.rs
@@ -18,7 +18,7 @@ thread_local!(static MAIN_LOOP_CALLBACK: RefCell<Option<Box<dyn FnMut()>>> = Ref
 
 unsafe extern "C" fn wrapper() {
     MAIN_LOOP_CALLBACK.with(|z| {
-        if let Some(ref mut main_loop) = &mut *z.borrow_mut() {
+        if let Some(main_loop) = &mut *z.borrow_mut() {
             main_loop();
         }
     });

--- a/playground/src/emscripten.rs
+++ b/playground/src/emscripten.rs
@@ -1,53 +1,38 @@
 #![cfg(target_os = "emscripten")]
-#![allow(dead_code)]
-#![allow(trivial_casts)]
-#![allow(unused_imports)]
 
 // taken from https://github.com/Gigoteur/PX8/blob/master/src/px8/emscripten.rs
 // taken from https://github.com/gliheng/rust-wasm/blob/d89a71f4a68101c7b4e2944973b39a2c20b21ebe/sdl2-drag/src/emscripten.rs
 
 use std::cell::RefCell;
-use std::ffi::{CStr, CString};
-use std::os::raw::{c_char, c_float, c_int, c_void};
-use std::ptr::null_mut;
+use std::os::raw::c_int;
 
 #[allow(non_camel_case_types)]
 type em_callback_func = unsafe extern "C" fn();
 
 extern "C" {
     // void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop)
-    pub fn emscripten_set_main_loop(
-        func: em_callback_func,
-        fps: c_int,
-        simulate_infinite_loop: c_int,
-    );
-
-    pub fn emscripten_cancel_main_loop();
-    pub fn emscripten_pause_main_loop();
-    pub fn emscripten_get_now() -> c_float;
+    fn emscripten_set_main_loop(func: em_callback_func, fps: c_int, simulate_infinite_loop: c_int);
 }
 
-thread_local!(static MAIN_LOOP_CALLBACK: RefCell<*mut c_void> = RefCell::new(null_mut()));
+thread_local!(static MAIN_LOOP_CALLBACK: RefCell<Option<Box<dyn FnMut()>>> = RefCell::new(None));
+
+unsafe extern "C" fn wrapper() {
+    MAIN_LOOP_CALLBACK.with(|z| {
+        if let Some(ref mut main_loop) = &mut *z.borrow_mut() {
+            main_loop();
+        }
+    });
+}
 
 pub fn set_main_loop_callback<F>(callback: F)
 where
-    F: FnMut(),
+    F: FnMut() + 'static,
 {
-    MAIN_LOOP_CALLBACK.with(|log| {
-        *log.borrow_mut() = &callback as *const _ as *mut c_void;
+    MAIN_LOOP_CALLBACK.with(|z| {
+        z.borrow_mut().replace(Box::new(callback));
     });
 
     unsafe {
-        emscripten_set_main_loop(wrapper::<F>, -1, 1);
-    }
-
-    unsafe extern "C" fn wrapper<F>()
-    where
-        F: FnMut(),
-    {
-        MAIN_LOOP_CALLBACK.with(|z| {
-            let closure = *z.borrow_mut() as *mut F;
-            (*closure)();
-        });
+        emscripten_set_main_loop(wrapper, -1, 1);
     }
 }


### PR DESCRIPTION
Lint the playground under the `wasm32-unknown-emscripten` target, remove raw pointers.