### PR TITLE
Improve playground TypeScript code

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -157,45 +157,47 @@ class Interpreter {
   };
 }
 
-let buttonEvalCounter = 0;
-let codeActionEvalCounter = 0;
-
-// Factory for an event handler that reads the source code int the editor
-// buffer and evals it on an embedded Artichoke Wasm interpreter.
+// Factory for an event handler that reads the source code in the editor buffer
+// and evals it on an embedded Artichoke Wasm interpreter.
 //
 // The output editor is updated with the contents of the report from the
 // interperter containing stdout, stderr, and the output from calling `inspect`
 // on the returned value.
-const playgroundRun = (interp: Interpreter, evalType: EvalType) => (): void => {
-  let counter: number;
-  switch (evalType) {
-    case EvalType.Button: {
-      buttonEvalCounter += 1;
-      counter = buttonEvalCounter;
-      break;
+const playgroundRun = (() => {
+  let buttonEvalCounter = 0;
+  let codeActionEvalCounter = 0;
+
+  return (interp: Interpreter, evalType: EvalType) => (): void => {
+    let counter: number;
+    switch (evalType) {
+      case EvalType.Button: {
+        buttonEvalCounter += 1;
+        counter = buttonEvalCounter;
+        break;
+      }
+      case EvalType.CodeAction: {
+        codeActionEvalCounter += 1;
+        counter = codeActionEvalCounter;
+        break;
+      }
     }
-    case EvalType.CodeAction: {
-      codeActionEvalCounter += 1;
-      counter = codeActionEvalCounter;
-      break;
-    }
-  }
 
-  const level = `playground-run-${evalType}-${counter}`;
-  window.gtag("event", "level_start", {
-    level_name: level,
-  });
+    const level = `playground-run-${evalType}-${counter}`;
+    window.gtag("event", "level_start", {
+      level_name: level,
+    });
 
-  const sourceLines = editor.getModel()?.getLinesContent() ?? [];
-  const source = sourceLines.join("\n");
-  const result = interp.evalRuby(source);
-  output.getModel()?.setValue(result);
+    const sourceLines = editor.getModel()?.getLinesContent() ?? [];
+    const source = sourceLines.join("\n");
+    const result = interp.evalRuby(source);
+    output.getModel()?.setValue(result);
 
-  window.gtag("event", "level_end", {
-    level_name: level,
-    success: true,
-  });
-};
+    window.gtag("event", "level_end", {
+      level_name: level,
+      success: true,
+    });
+  };
+})();
 
 Module().then((wasm: Module.Ffi): void => {
   const level = `playground-interpreter-init`;

--- a/src/main.ts
+++ b/src/main.ts
@@ -220,9 +220,9 @@ Module().then((wasm: Module.Ffi): void => {
   );
 
   // Add an editor action to run the buffer in an Artichoke Wasm interpreter.
-  // This action is triggered by Ctrl/Cmd+F8 (play button on a mac keyboard) and
-  // has the same side effects as clicking the "Run" button in the webapp
-  // chrome.
+  // This action is triggered by Ctrl/Cmd+F8 (the "play" button on a Mac
+  // keyboard) and has the same side effects as clicking the "Run" button in the
+  // webapp chrome.
   editor.addAction({
     id: "artichoke-playground-run-ruby",
     label: "Run Ruby source code",

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,7 +96,7 @@ if (urlParams.has("embed")) {
 }
 
 class Interpreter {
-  private readonly state: number;
+  private readonly state: Module.Artichoke;
   private evalCounter: number;
 
   constructor(private readonly wasm: Module.Ffi) {
@@ -108,7 +108,7 @@ class Interpreter {
   // one byte at a time.
   //
   // Strings are UTF-8 encoded byte vectors.
-  read = (ptr: number): string => {
+  read = (ptr: Module.StringPointer): string => {
     const len: number = this.wasm._artichoke_string_getlen(this.state, ptr);
     const bytes = [];
     for (let idx = 0; idx < len; idx += 1) {
@@ -122,7 +122,7 @@ class Interpreter {
   // a time.
   //
   // Strings are UTF-8 encoded byte vectors.
-  write = (s: string): number => {
+  write = (s: string): Module.StringPointer => {
     const ptr = this.wasm._artichoke_string_new(this.state);
     const bytes = new TextEncoder().encode(s);
     for (let idx = 0; idx < bytes.length; idx += 1) {
@@ -209,7 +209,7 @@ Module().then((wasm: Module.Ffi): void => {
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const buildInfoElement = document.getElementById("artichoke-build-info")!;
-  buildInfoElement.textContent = artichoke.read(0);
+  buildInfoElement.textContent = artichoke.read(0 as Module.StringPointer);
 
   // When the user clicks the "Run" button, grab the source code from the editor
   // buffer and eval it on an Artichoke Wasm interpreter.

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,10 +96,10 @@ if (urlParams.has("embed")) {
 }
 
 class Interpreter {
-  private state: number;
+  private readonly state: number;
   private evalCounter: number;
 
-  constructor(private wasm: Module.Ffi) {
+  constructor(private readonly wasm: Module.Ffi) {
     this.state = wasm._artichoke_web_repl_init();
     this.evalCounter = 0;
   }

--- a/src/wasm/playground.d.ts
+++ b/src/wasm/playground.d.ts
@@ -1,20 +1,34 @@
 declare function Module(): Module.Thenable;
 
+declare const ArtichokeType: unique symbol;
+declare const StringPointerType: unique symbol;
+
 declare namespace Module {
   export class Thenable {
     then(thunk: (wasm: Ffi) => void): void;
   }
 
+  export type Artichoke = number & { _opqaque: typeof ArtichokeType };
+  export type StringPointer = number & { _opaque: typeof StringPointerType };
+
   export class Ffi {
-    _artichoke_web_repl_init(): number;
+    _artichoke_web_repl_init(): Artichoke;
 
-    _artichoke_string_getlen(state: number, ptr: number): number;
-    _artichoke_string_getch(state: number, ptr: number, index: number): number;
-    _artichoke_string_new(state: number): number;
-    _artichoke_string_putch(state: number, ptr: number, byte: number): void;
-    _artichoke_string_free(state: number, ptr: number): void;
+    _artichoke_string_getlen(state: Artichoke, ptr: StringPointer): number;
+    _artichoke_string_getch(
+      state: Artichoke,
+      ptr: StringPointer,
+      index: number
+    ): number;
+    _artichoke_string_new(state: Artichoke): StringPointer;
+    _artichoke_string_putch(
+      state: Artichoke,
+      ptr: StringPointer,
+      byte: number
+    ): void;
+    _artichoke_string_free(state: Artichoke, ptr: StringPointer): void;
 
-    _artichoke_eval(state: number, codeptr: number): number;
+    _artichoke_eval(state: Artichoke, codeptr: StringPointer): StringPointer;
   }
 }
 


### PR DESCRIPTION
- Add `readonly` field qualifier to members of the `Interpreter` class.
- Scope mutable numeric level counters used in the `playgroundRun` factory to an immediately-invoked function expression.
- Fixup some awkward wording in a comment about keyboard modifiers for setting up a Monaco Editor run action.
- Improve the typing of the WebAssembly "extern" type definitions by using opaque "extern types" for the Artichoke state and string pointers, which moves the types away from _everything is a `void*`_.