### PR TITLE
Configure cargo to fetch the Artichoke git dependency with the git CLI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
libgit2 is very slow (on the order of 5-10 minutes) to fetch Artichoke when the git revision changes.

This appears to be tracked upstream in `libgit2` here:

- https://github.com/libgit2/libgit2/issues/4674
- https://github.com/libgit2/libgit2/issues/6038

This change speeds up local builds a bunch.