### PR TITLE
Upgrade artichoke dependency to latest trunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 [[package]]
 name = "artichoke"
 version = "0.1.0-pre.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "artichoke-backend",
  "chrono",
@@ -23,8 +23,8 @@ dependencies = [
 
 [[package]]
 name = "artichoke-backend"
-version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+version = "0.3.0"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "artichoke-core",
  "artichoke-load-path",
@@ -50,13 +50,13 @@ dependencies = [
 
 [[package]]
 name = "artichoke-core"
-version = "0.8.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+version = "0.10.0"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 
 [[package]]
 name = "artichoke-load-path"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 
 [[package]]
 name = "autocfg"
@@ -273,6 +273,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-parts"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40212472c0965c24516ac3e87ffeafc3bfd67274ad699dff8985e80d147644be"
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,25 +298,28 @@ checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 [[package]]
 name = "scolapasta-hex"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 
 [[package]]
 name = "scolapasta-string-escape"
 version = "0.2.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "bstr",
 ]
 
 [[package]]
 name = "spinoso-array"
-version = "0.5.2"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+version = "0.7.0"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
+dependencies = [
+ "raw-parts",
+]
 
 [[package]]
 name = "spinoso-env"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "bstr",
  "scolapasta-string-escape",
@@ -319,15 +328,15 @@ dependencies = [
 [[package]]
 name = "spinoso-exception"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "scolapasta-string-escape",
 ]
 
 [[package]]
 name = "spinoso-math"
-version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+version = "0.2.0"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "libm",
 ]
@@ -335,7 +344,7 @@ dependencies = [
 [[package]]
 name = "spinoso-random"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "getrandom",
  "libm",
@@ -345,8 +354,8 @@ dependencies = [
 
 [[package]]
 name = "spinoso-regexp"
-version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+version = "0.2.0"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "bitflags",
  "bstr",
@@ -358,7 +367,7 @@ dependencies = [
 [[package]]
 name = "spinoso-securerandom"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "base64",
  "rand",
@@ -368,7 +377,7 @@ dependencies = [
 [[package]]
 name = "spinoso-symbol"
 version = "0.1.0"
-source = "git+https://github.com/artichoke/artichoke.git?rev=5b0b0e54cafd465008822e809d979e8b5c23d43c#5b0b0e54cafd465008822e809d979e8b5c23d43c"
+source = "git+https://github.com/artichoke/artichoke.git?rev=6797c1844e1c3fe620157c04b8125bb43fcd0594#6797c1844e1c3fe620157c04b8125bb43fcd0594"
 dependencies = [
  "artichoke-core",
  "bstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "playground"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "artichoke",
  "bstr",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artichokeruby/playground",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@artichokeruby/playground",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@artichokeruby/logo": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichokeruby/playground",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "Artichoke Ruby Wasm Playground",
   "keywords": [

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -19,7 +19,7 @@ bstr = { version = "0.2, >= 0.2.4", default-features = false }
 [dependencies.artichoke]
 version = "0.1.0-pre.0"
 git = "https://github.com/artichoke/artichoke.git"
-rev = "5b0b0e54cafd465008822e809d979e8b5c23d43c"
+rev = "6797c1844e1c3fe620157c04b8125bb43fcd0594"
 default-features = false
 features = [
   "core-env",

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playground"
-version = "0.6.0" # remember to bump package.json
+version = "0.7.0" # remember to bump package.json
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2018"

--- a/playground/src/meta.rs
+++ b/playground/src/meta.rs
@@ -3,11 +3,11 @@ use artichoke::prelude::{Value as _, *};
 pub fn build_info(interp: &mut Artichoke) -> String {
     let mut description = interp
         .eval(b"RUBY_DESCRIPTION")
-        .and_then(|value| value.try_into_mut::<String>(interp))
+        .and_then(|value| value.try_convert_into_mut::<String>(interp))
         .unwrap_or_default();
     let compiler = interp
         .eval(b"ARTICHOKE_COMPILER_VERSION")
-        .and_then(|value| value.try_into_mut::<&str>(interp))
+        .and_then(|value| value.try_convert_into_mut::<&str>(interp))
         .unwrap_or_default();
     description.push('\n');
     description.push('[');


### PR DESCRIPTION
Upgrade the artichoke git dependency to the latest trunk commit: artichoke/artichoke@6797c1844e1c3fe620157c04b8125bb43fcd0594.

The required toolchain upgrades were previously landed in #699.