### PR TITLE
Convert `build.js` build script to ESM module

### DIFF
--- a/.github/workflows/playground.yaml
+++ b/.github/workflows/playground.yaml
@@ -67,7 +67,7 @@ jobs:
         run: ruby scripts/build-wasm.rb --release --verbose
 
       - name: Build Webapp
-        run: node build.js --release
+        run: node build.mjs --release
 
       - name: Deploy Playground
         uses: peaceiris/actions-gh-pages@v3

--- a/build.mjs
+++ b/build.mjs
@@ -1,14 +1,23 @@
+/* eslint-disable no-console */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const fs = require("fs").promises;
-const path = require("path");
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const eta = require("eta");
-const esbuild = require("esbuild");
+import { renderFile } from "eta";
+import esbuild from "esbuild";
+
+// eslint-disable-next-line no-shadow
+const require = createRequire(import.meta.url);
 const minifyHtml = require("@minify-html/js");
+
+// eslint-disable-next-line no-shadow
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
 
 const assets = Object.freeze([
   "src/assets/robots.txt",
@@ -54,11 +63,12 @@ const build = async () => {
     path.join(__dirname, "dist", "playground.wasm")
   );
 
-  let index = await eta.renderFile(
+  let index = await renderFile(
     "index.html",
     {},
     { views: path.join(__dirname, "src") }
   );
+
   if (process.argv.includes("--release")) {
     const cfg = minifyHtml.createConfiguration({
       ensure_spec_compliant_unquoted_attribute_values: true,
@@ -68,8 +78,10 @@ const build = async () => {
       minify_css: true,
       remove_bangs: false,
     });
+
     index = minifyHtml.minify(index, cfg);
   }
+
   await fs.writeFile(path.join(__dirname, "dist", "index.html"), index);
 
   await esbuild.build({
@@ -95,8 +107,8 @@ const build = async () => {
 (async function main() {
   try {
     await build();
-  } catch (err) {
-    console.error(err);
+  } catch (error) {
+    console.error(error);
     process.exit(1);
   }
 })();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     },
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
+      "extraFileExtensions": [
+        ".mjs"
+      ],
       "project": "./tsconfig.json"
     },
     "plugins": [
@@ -70,19 +73,19 @@
   },
   "scripts": {
     "build:debug": "npx concurrently --max-processes 1 \"npm:build:debug:wasm\" \"npm:build:debug:app\"",
-    "build:debug:app": "node build.js",
+    "build:debug:app": "node build.mjs",
     "build:debug:wasm": "ruby scripts/build-wasm.rb",
     "build:release": "npx concurrently --max-processes 1 \"npm:build:release:wasm\" \"npm:build:release:app\"",
-    "build:release:app": "node build.js --release",
+    "build:release:app": "node build.mjs --release",
     "build:release:wasm": "ruby scripts/build-wasm.rb --release",
     "clean": "rm -rf dist",
     "dev:debug": "npx concurrently \"npm:serve\" \"npm:watch:debug\"",
     "dev:release": "npx concurrently \"npm:serve\" \"npm:watch:release\"",
     "fmt": "npx prettier --write \"**/*\"",
-    "lint": "npx eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "npx eslint . --ext .js,.jsx,.ts,.tsx --fix",
+    "lint": "npx eslint . --ext .js,.jsx,.mjs,.ts,.tsx",
+    "lint:fix": "npx eslint . --ext .js,.jsx,.mjs,.ts,.tsx --fix",
     "serve": "python3 -u -m http.server --directory dist --bind 127.0.0.1 0",
-    "watch:debug": "npx chokidar-cli \"**/Cargo.toml\" \"Cargo.lock\" \"package.json\" \"package-lock.json\" \"playground/**/*\" \"build.js\" \"src/**/*\" -c \"npm run build:debug\" --initial",
-    "watch:release": "npx chokidar-cli \"**/Cargo.toml\" \"Cargo.lock\" \"package.json\" \"package-lock.json\" \"playground/**/*\" \"build.js\" \"src/**/*\" -c \"npm run build:release\" --initial"
+    "watch:debug": "npx chokidar-cli \"**/Cargo.toml\" \"Cargo.lock\" \"package.json\" \"package-lock.json\" \"playground/**/*\" \"build.mjs\" \"src/**/*\" -c \"npm run build:debug\" --initial",
+    "watch:release": "npx chokidar-cli \"**/Cargo.toml\" \"Cargo.lock\" \"package.json\" \"package-lock.json\" \"playground/**/*\" \"build.mjs\" \"src/**/*\" -c \"npm run build:release\" --initial"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,5 @@
     "jsx": "react",
     "moduleResolution": "node"
   },
-  "include": ["src/**/*.ts", "src/**/*.js", "build.js"]
+  "include": ["src/**/*.ts", "src/**/*.js", "build.mjs"]
 }


### PR DESCRIPTION
Apply some off-by-default eslint rules too. The biggest change is to use the `node:` protocol for importing built-in modules.