### PR TITLE
Add GitHub Actions workflow to run markdown-link-check

### DIFF
--- a/.github/workflows/markdown-link-check.yaml
+++ b/.github/workflows/markdown-link-check.yaml
@@ -1,0 +1,32 @@
+---
+"on":
+  push:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  pull_request:
+    branches:
+      - trunk
+    paths:
+      - .github/markdown-link-check.json
+      - .github/workflows/markdown-link-check.yaml
+      - "**/*.md"
+  schedule:
+    - cron: "0 0 * * TUE"
+name: Markdown Links Check
+jobs:
+  check-links:
+    name: Check links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        # checks all markdown files from /docs including all subfolders
+        with:
+          use-quiet-mode: "yes"
+          use-verbose-mode: "yes"
+          config-file: ".github/markdown-link-check.json"
+          folder-path: "."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,16 @@ cargo clippy --all-targets --all-features
 
 ### C Toolchain
 
-Some artichoke dependencies, like the mruby [`sys`](artichoke-backend/src/sys)
-FFI bindings and the [`onig`] crate, build C static libraries and require a C
-compiler.
+The Playground's `artichoke` dependency and several other transitive
+dependencies build C static libraries and require a C compiler.
 
-Artichoke specifically requires clang. WebAssembly targets require clang-8 or
-newer.
+The Artichoke Playground specifically requires emcc. Install the appropriate
+emscripten toolchain defined in [`emscripten-toolchain`](emscripten-toolchain)
+or source the included helper in your shell:
 
-On Windows, install the latest LLVM distribution from GitHub and add LLVM to
-your PATH: <https://github.com/llvm/llvm-project/releases>.
+```sh
+. scripts/install-emscripten-toolchain.sh
+```
 
 #### `cc` Crate
 


### PR DESCRIPTION
Artichoke already incorporates this tool in the `Rakefile` as the
`release:markdown_link_check` task, but it is slow and doesn't get
regularly run.

Incorporate this into CI such that links are checked on every PR that
touches markdown files and on a weekly cron with the same cadence as the
audit workflow.