### PR TITLE
Run eslint with 'npm run lint' in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,8 +124,8 @@ jobs:
       - name: Compile with TypeScript
         run: npx tsc --extendedDiagnostics --listFiles --listEmittedFiles
 
-      - name: Lint and check formatting with eslint
-        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+      - name: Lint with eslint
+        run: npm run lint
 
   text:
     name: Lint and format text


### PR DESCRIPTION
Delegate to the npm run script in CI which is more likely to be updated since it is used in the local development loop.