### PR TITLE
Rollup @dependabot Rust crate updates for February 2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,15 +121,15 @@ dependencies = [
 
 [[package]]
 name = "focaccia"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdea8da000c6a33ffd516c57b6d2c07080eda0c52ac56d2fb6ccdde71f2f0cde"
+checksum = "81a5987956b8394019bd75c05158075f9c14ffed5bb7f0d100569d224094947e"
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -150,9 +150,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
 
 [[package]]
 name = "libm"
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "unicode-xid"


### PR DESCRIPTION
```console
$ cargo update
    Updating git repository `https://github.com/artichoke/artichoke.git`
    Updating crates.io index
    Updating focaccia v1.1.0 -> v1.1.2
    Updating getrandom v0.2.3 -> v0.2.4
    Updating libc v0.2.112 -> v0.2.116
    Updating quote v1.0.14 -> v1.0.15
    Updating target-lexicon v0.12.2 -> v0.12.3
```

Rollup of:

- https://github.com/artichoke/playground/pull/768
- https://github.com/artichoke/playground/pull/766
- https://github.com/artichoke/playground/pull/765
- https://github.com/artichoke/playground/pull/767
- https://github.com/artichoke/playground/pull/764