### PR TITLE
Update Cargo.toml manifest versions

### DIFF
--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["artichoke", "artichoke-ruby", "playground", "ruby", "wasm"]
 categories = ["emulators", "wasm", "web-programming"]
 
 [dependencies]
-bstr = { version = "0.2, >= 0.2.4", default-features = false }
+bstr = { version = "0.2.17", default-features = false }
 
 [dependencies.artichoke]
 version = "0.1.0-pre.0"


### PR DESCRIPTION
- Use precise versions for dependencies. See: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277

See:

- https://github.com/artichoke/artichoke/pull/1688