### PR TITLE
Can't build, but heres are some not important things

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ development server with:
 
 ```sh
 rustup target add wasm32-unknown-emscripten
+npm ci
+cargo install bindgen
 . scripts/install-emscripten-toolchain.sh
 npm run dev:debug # or npm run dev:release
 ```

--- a/scripts/build-wasm.rb
+++ b/scripts/build-wasm.rb
@@ -48,7 +48,7 @@ module Artichoke
         #
         # - https://github.com/zackradisic/cheatsheets/issues/21#issuecomment-969393554
         # - https://github.com/rust-lang/rust/issues/85821#issuecomment-969369677
-        ENV['EMMAKEN_CFLAGS'] = '-s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry'
+        ENV['EMCC_CFLAGS'] = '-s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry'
 
         if verbose
           `cargo build --target wasm32-unknown-emscripten --verbose`
@@ -76,7 +76,7 @@ module Artichoke
         #
         # - https://github.com/zackradisic/cheatsheets/issues/21#issuecomment-969393554
         # - https://github.com/rust-lang/rust/issues/85821#issuecomment-969369677
-        ENV['EMMAKEN_CFLAGS'] = '-s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry'
+        ENV['EMCC_CFLAGS'] = '-s ERROR_ON_UNDEFINED_SYMBOLS=0 --no-entry'
 
         if verbose
           `cargo build --target wasm32-unknown-emscripten --release --verbose`


### PR DESCRIPTION
I'm trying to build the playground, but I don't know why it always failed

My environment:

- M1 Mac
- Latest macOS and XCode
- Runned `scripts/install-emscripten-toolchain.sh`

In first attempt, the build failed because "warning: emcc: error: `EMMAKEN_CFLAGS` is no longer supported, please use `EMCC_CFLAGS` instead"

[build.log](https://github.com/artichoke/playground/files/8238641/build.log)

Then I replace `EMMAKEN_CFLAGS` with `EMCC_CFLAGS`, it failed again because

```
  error: linking with `cc` failed: exit status: 1
    |
    = note: "cc" "-arch" "arm64" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.0.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.1.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.10.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.11.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.12.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.13.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.14.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.15.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.2.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.3.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.4.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.5.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.6.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.7.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.8.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.build_script_build.215381f2-cgu.9.rcgu.o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f.1dsxf8w3nz7thhrj.rcgu.o" "-L" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/deps" "-L" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd-3e9242c3cd2b7504.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libpanic_unwind-21fb160eabff0de9.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libobject-db30465a1eaface5.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libmemchr-e382952d2c548344.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libaddr2line-ec20cbcde7f93da6.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libgimli-9ab26dd50e2d2400.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libstd_detect-2a0541465d7990f5.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_demangle-ca5a8bf0e1c973cd.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libhashbrown-661f613758a122d7.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_alloc-e3fb6213fb083b7c.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libunwind-e47fb12d3d9565f1.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcfg_if-5d995d79ef7c7cbe.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liblibc-195c03df6e48132d.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/liballoc-706d571a09b848f6.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/librustc_std_workspace_core-581e7c3ef8936945.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcore-61f7a53bba9c6667.rlib" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-62ccedd146f025b3.rlib" "-lSystem" "-lresolv" "-lc" "-lm" "-liconv" "-L" "/Users/jasl/.rustup/toolchains/1.56.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib" "-o" "/var/folders/z8/v1b2v_cs7zx404tc9h0rrm_00000gn/T/cargo-installQu5Hm5/release/build/proc-macro2-6f81de82f8a5ef7f/build_script_build-6f81de82f8a5ef7f" "-Wl,-dead_strip" "-nodefaultlibs" "-s" "MODULARIZE=1" "-s" "WASM=1" "-s" "ENVIRONMENT=web" "-s" "SUPPORT_LONGJMP=1"
    = note: clang: error: no such file or directory: 'MODULARIZE=1'
            clang: error: no such file or directory: 'WASM=1'
            clang: error: no such file or directory: 'ENVIRONMENT=web'
            clang: error: no such file or directory: 'SUPPORT_LONGJMP=1'
           
```
[build_1.log](https://github.com/artichoke/playground/files/8238644/build_1.log)
