### PR TITLE
deps(security): Update `regex` crate to 1.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,9 +280,9 @@ checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",


### PR DESCRIPTION
See:

- GHSA-m5pq-gvj9-9vr8
- CVE-2022-24713
- rust-lang/regex@ae70b41
- https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw/m/jiZv_PAABQAJ
- https://rustsec.org/advisories/RUSTSEC-2022-0013
- https://github.com/artichoke/artichoke/pull/1729
- https://github.com/artichoke/artichoke/commit/ad6ccbe833473240d7eb64039361e63df20be87c

```console
$ cargo deny check
error[A001]: Regexes with large repetitions on empty sub-expressions take a very long time to parse
   ┌─ /Users/lopopolo/dev/artichoke/playground/Cargo.lock:34:1
   │
34 │ regex 1.5.4 registry+https://github.com/rust-lang/crates.io-index
   │ ----------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2022-0013
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0013
   = The Rust Security Response WG was notified that the `regex` crate did not
     properly limit the complexity of the regular expressions (regex) it parses. An
     attacker could use this security issue to perform a denial of service, by
     sending a specially crafted regex to a service accepting untrusted regexes. No
     known vulnerability is present when parsing untrusted input with trusted
     regexes.

     This issue has been assigned CVE-2022-24713. The severity of this vulnerability
     is "high" when the `regex` crate is used to parse untrusted regexes. Other uses
     of the `regex` crate are not affected by this vulnerability.

     ## Overview

     The `regex` crate features built-in mitigations to prevent denial of service
     attacks caused by untrusted regexes, or untrusted input matched by trusted
     regexes. Those (tunable) mitigations already provide sane defaults to prevent
     attacks. This guarantee is documented and it's considered part of the crate's
     API.

     Unfortunately a bug was discovered in the mitigations designed to prevent
     untrusted regexes to take an arbitrary amount of time during parsing, and it's
     possible to craft regexes that bypass such mitigations. This makes it possible
     to perform denial of service attacks by sending specially crafted regexes to
     services accepting user-controlled, untrusted regexes.

     ## Affected versions

     All versions of the `regex` crate before or equal to 1.5.4 are affected by this
     issue. The fix is include starting from  `regex` 1.5.5.

     ## Mitigations

     We recommend everyone accepting user-controlled regexes to upgrade immediately
     to the latest version of the `regex` crate.

     Unfortunately there is no fixed set of problematic regexes, as there are
     practically infinite regexes that could be crafted to exploit this
     vulnerability. Because of this, we do not recommend denying known problematic
     regexes.

     ## Acknowledgements

     We want to thank Addison Crump for responsibly disclosing this to us according
     to the [Rust security policy][1], and for helping review the fix.

     We also want to thank Andrew Gallant for developing the fix, and Pietro Albini
     for coordinating the disclosure and writing this advisory.

     [1]: https://www.rust-lang.org/policies/security
   = Announcement: https://groups.google.com/g/rustlang-security-announcements/c/NcNNL1Jq7Yw
   = Solution: Upgrade to >=1.5.5
   = regex v1.5.4
     ├── artichoke-backend v0.3.0
     │   └── artichoke v0.1.0-pre.0
     │       └── playground v0.7.0
     └── spinoso-regexp v0.2.0
         └── artichoke-backend v0.3.0 (*)

advisories FAILED, bans ok, licenses ok, sources ok
```