### PR TITLE
chore: Update `.github/workflows/audit.yaml` in `artichoke/playground`

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -50,16 +50,27 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install stable --profile minimal
+          echo "::endgroup::"
+          echo "::group::set default toolchain"
+          rustup default stable
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - name: Generate Cargo.lock
         run: |
           if [[ ! -f "Cargo.lock" ]]; then
-            cargo generate-lockfile --verbose
+            cargo +stable generate-lockfile --verbose
           fi
 
       - name: Setup cargo-deny


### PR DESCRIPTION
Managed by Terraform.

See:

- https://github.com/artichoke/artichoke/pull/1813

## Contents

```
---
name: Audit
"on":
  push:
    branches:
      - trunk
  pull_request:
    branches:
      - trunk
  schedule:
    - cron: "0 0 * * TUE"
jobs:
  js:
    name: Audit JS Dependencies
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Nodejs toolchain
        run: npm ci

      - name: npm audit
        run: npm audit

  ruby:
    name: Audit Ruby Dependencies
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Ruby toolchain
        uses: ruby/setup-ruby@v1
        with:
          ruby-version: ".ruby-version"
          bundler-cache: true

      - name: bundler-audit
        run: bundle exec bundle-audit check --update

  rust:
    name: Audit Rust Dependencies
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v3

      - name: Install Rust toolchain
        run: |
          echo "::group::rustup toolchain install"
          rustup toolchain install stable --profile minimal
          echo "::endgroup::"
          echo "::group::set default toolchain"
          rustup default stable
          echo "::endgroup::"
          echo "::group::rustup version"
          rustup -Vv
          echo "::endgroup::"
          echo "::group::rustc version"
          rustc -Vv
          echo "::endgroup::"
          echo "::group::cargo version"
          cargo version --verbose
          echo "::endgroup::"

      - name: Generate Cargo.lock
        run: |
          if [[ ! -f "Cargo.lock" ]]; then
            cargo +stable generate-lockfile --verbose
          fi

      - name: Setup cargo-deny
        run: curl -sL "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.11.3/cargo-deny-0.11.3-x86_64-unknown-linux-musl.tar.gz" | sudo tar xvz -C /usr/local/bin/ --strip-components=1

      - name: Show cargo-deny version
        run: cargo-deny --version

      - name: Run cargo-deny
        run: cargo-deny --locked check --show-stats
```