### PR TITLE
Remove cargo deny ignore directive for RUSTSEC-2020-0159

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,9 +204,9 @@ checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "scolapasta-hex"

--- a/deny.toml
+++ b/deny.toml
@@ -2,11 +2,7 @@
 vulnerability = "deny"
 unmaintained = "deny"
 notice = "warn"
-ignore = [
-  # time/chrono problems, have not been a problem in practice
-  # see: https://github.com/chronotope/chrono/issues/499
-  "RUSTSEC-2020-0159",
-]
+ignore = []
 
 [licenses]
 unlicensed = "deny"


### PR DESCRIPTION
chrono is no longer used in the Artichoke dependency since
https://github.com/artichoke/artichoke/pull/1832.

```
warning[A007]: advisory was not encountered
  ┌─ /Users/lopopolo/dev/artichoke/playground/deny.toml:8:3
  │
8 │   "RUSTSEC-2020-0159",
  │   ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria
```