### PR TITLE
Rollup of cargo dependabot updates for September 2022

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "focaccia"
-version = "1.1.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a5987956b8394019bd75c05158075f9c14ffed5bb7f0d100569d224094947e"
+checksum = "0bf0a769c74a0ab16fad2ad5ef4b4432d2ba3d079e607c55083e66d3f9d1bb8f"
 
 [[package]]
 name = "getrandom"
@@ -113,21 +113,21 @@ dependencies = [
 
 [[package]]
 name = "intaglio"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd49aef5b63b46af0844b99cea402c3063d9a052249265d322657d83cf464211"
+checksum = "1665db2526543d5fca893c1004e6a908953fb6c64c44b03b2f41267f89e5f881"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libm"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da83a57f3f5ba3680950aa3cbc806fc297bc0b289d42e8942ed528ace71b8145"
+checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
 
 [[package]]
 name = "memchr"
@@ -174,15 +174,15 @@ dependencies = [
 
 [[package]]
 name = "rand_mt"
-version = "4.1.3"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30605ed38110721cffe812de8f878a1418a310831a3afd73e294b912222cd7c0"
+checksum = "6cf6dbbecdfb1522a112f5ecb746c3093e2743819f79d454502d142dd53c48e0"
 
 [[package]]
 name = "raw-parts"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d684eb692d561551750a408e516759f550d51033179e7d2f676efc4495b3d4e"
+checksum = "b1e22ce49f28be0887a992cf42172c8c75facdb74e3e1a7eb0f459cf2fcc95d7"
 
 [[package]]
 name = "regex"
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "tz-rs"
-version = "0.6.12"
+version = "0.6.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3d23fda22515e0e3f4f903e159ad4fd32e37dc94d63522a091df70a247fbb0"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
 
 [[package]]
 name = "wasi"

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,7 @@ unlicensed = "deny"
 allow = [
   "Apache-2.0",
   "MIT",
+  "Unicode-DFS-2016",
 ]
 deny = []
 copyleft = "deny"


### PR DESCRIPTION
Rollup of September 2022 https://github.com/dependabot updates:

- https://github.com/artichoke/playground/pull/901
- https://github.com/artichoke/playground/pull/902
- https://github.com/artichoke/playground/pull/903
- https://github.com/artichoke/playground/pull/904
- https://github.com/artichoke/playground/pull/905
- https://github.com/artichoke/playground/pull/906
- https://github.com/artichoke/playground/pull/907

```console
$ cargo update
    Updating git repository `https://github.com/artichoke/artichoke.git`
    Updating crates.io index
    Updating focaccia v1.1.2 -> v1.2.0
    Updating intaglio v1.6.1 -> v1.7.0
    Updating libc v0.2.127 -> v0.2.132
    Updating libm v0.2.3 -> v0.2.5
    Updating rand_mt v4.1.3 -> v4.2.0
    Updating raw-parts v1.1.1 -> v1.1.2
    Updating tz-rs v0.6.12 -> v0.6.14
```