### PR TITLE
Refactor CI and Playground build pipelines

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,20 +10,37 @@ name: CI
   schedule:
     - cron: "0 0 * * TUE"
 jobs:
-  build:
-    name: Build
+  build-rust:
+    name: Build Rust
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set toolchain versions
+        run: |
+          echo "::set-output name=rust::$(cat rust-toolchain)"
+          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+        id: toolchain_versions
+
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install ${{ steps.toolchain_versions.outputs.rust }} --profile minimal
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
@@ -36,12 +53,13 @@ jobs:
       - name: Test
         run: cargo test --workspace
 
-  rust:
-    name: Lint and format Rust
+  build-webapp:
+    name: Build Webapp
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -53,11 +71,19 @@ jobs:
         id: toolchain_versions
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          components: rustfmt, clippy
-          target: wasm32-unknown-emscripten
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install ${{ steps.toolchain_versions.outputs.rust }} --profile minimal --target wasm32-unknown-emscripten
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
@@ -71,24 +97,70 @@ jobs:
         uses: mymindstorm/setup-emsdk@v11
         with:
           version: ${{ steps.toolchain_versions.outputs.emscripten }}
+          no-cache: true
+
+      - name: Verify emcc version
+        run: emcc -v
+
+      - name: Install Nodejs toolchain
+        run: npm ci
+
+      - name: Compile Wasm
+        run: ruby scripts/build-wasm.rb --release --verbose
+
+      - name: Build Webapp
+        run: node build.mjs --release
+
+  rust:
+    name: Lint and format Rust
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+      RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set toolchain versions
+        run: |
+          echo "::set-output name=rust::$(cat rust-toolchain)"
+          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+        id: toolchain_versions
+
+      - name: Install Rust toolchain
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install ${{ steps.toolchain_versions.outputs.rust }} --profile minimal --target wasm32-unknown-emscripten --component rustfmt clippy
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: Install Emscripten toolchain
+        uses: mymindstorm/setup-emsdk@v11
+        with:
+          version: ${{ steps.toolchain_versions.outputs.emscripten }}
 
       - name: Verify emcc version
         run: emcc -v
 
       - name: Check formatting
-        run: cargo fmt -- --check --color=auto
+        run: cargo fmt --check
 
       - name: Lint with Clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features --all-targets
+        run: cargo clippy --workspace --all-features --all-targets
 
       - name: Lint with Clippy on emscripten target
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --all-features --all-targets --target wasm32-unknown-emscripten
+        run: cargo clippy --workspace --all-features --all-targets --target wasm32-unknown-emscripten
 
   ruby:
     name: Lint and format Ruby

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,23 +1,29 @@
 ---
-name: Playground
+name: Publish
 "on":
   push:
     branches:
       - trunk
-  pull_request:
-    branches:
-      - trunk
-  schedule:
-    - cron: "0 0 * * TUE"
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
-  group: playground-${{ github.head_ref }}
+  group: "pages"
+  cancel-in-progress: true
+
 jobs:
+  # Build job
   build:
     name: Build Playground
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
 
     steps:
       - name: Checkout repository
@@ -30,11 +36,19 @@ jobs:
         id: toolchain_versions
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          target: wasm32-unknown-emscripten
-          profile: minimal
-          override: true
+        run: |
+          echo "::group::rustup toolchain install"
+          rustup toolchain install ${{ steps.toolchain_versions.outputs.rust }} --profile minimal --target wasm32-unknown-emscripten
+          echo "::endgroup::"
+          echo "::group::rustup version"
+          rustup -Vv
+          echo "::endgroup::"
+          echo "::group::rustc version"
+          rustc -Vv
+          echo "::endgroup::"
+          echo "::group::cargo version"
+          cargo version --verbose
+          echo "::endgroup::"
 
       - uses: Swatinem/rust-cache@v1
 
@@ -44,18 +58,11 @@ jobs:
           ruby-version: ".ruby-version"
           bundler-cache: true
 
-      - name: Cache emsdk
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: "emsdk-cache"
-          key: emscripten-emsdk-${{ runner.os }}-emsdk-${{ steps.toolchain_versions.outputs.emscripten }}
-
       - name: Install Emscripten toolchain
         uses: mymindstorm/setup-emsdk@v11
         with:
           version: ${{ steps.toolchain_versions.outputs.emscripten }}
-          actions-cache-folder: "emsdk-cache"
+          no-cache: true
 
       - name: Verify emcc version
         run: emcc -v
@@ -69,9 +76,9 @@ jobs:
       - name: Build Webapp
         run: node build.mjs --release
 
+      # Publish step
       - name: Deploy Playground
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/trunk'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist


### PR DESCRIPTION
This commit separates "build / test" and "publish" into separate pipelines to prepare for uploading to GitHub Pages with GitHub Actions:

- A WebApp build CI step is added which compiles the Rust code to Wasm and builds the TypeScript code into a bundle. This step never uploads to GitHub pages and runs on PRs and merges to trunk.
- A "Publish" workflow is added which builds and uploads to GitHub Pages. This workflow only runs on merges to trunk. A concurrency group called "pages" is added with canceling of in flight builds if a newer commit is pushed to trunk. The publish workflow is no longer published on a weekly cronjob.

This commit also contains some cleanups:

- `actions-rs` GitHub Actions are replaced with bare calls to rustup and clippy, addressing artichoke/project-infrastructure#265 for the playground.
- Caching is removed from `setup-emsdk` action due to an upstream bug: mymindstorm/setup-emsdk#20.
- `ruby/setup-ruby` is removed from CI jobs where it is not required.
- The `CARGO_NET_GIT_FETCH_WITH_CLI` env variable is set, porting a change from `strftime-ruby`. This should speed up build times when the Artichoke git repository is not cached.