### PR TITLE
Fix GITHUB_TOKEN permissions in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,12 +5,6 @@ name: Publish
     branches:
       - trunk
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: true


### PR DESCRIPTION
Fix a regression introduced in #909. These permissions from the GitHub Actions
based publishing workflow do not work with peaceiris/actions-gh-pages@v3.