### PR TITLE
Address deprecated 'set-output' command in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Set toolchain versions
         run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+          echo "rust=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+          echo "emscripten=$(cat emscripten-toolchain)" >> $GITHUB_OUTPUT
         id: toolchain_versions
 
       - name: Install Rust toolchain
@@ -66,8 +66,8 @@ jobs:
 
       - name: Set toolchain versions
         run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+          echo "rust=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+          echo "emscripten=$(cat emscripten-toolchain)" >> $GITHUB_OUTPUT
         id: toolchain_versions
 
       - name: Install Rust toolchain
@@ -124,8 +124,8 @@ jobs:
 
       - name: Set toolchain versions
         run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+          echo "rust=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+          echo "emscripten=$(cat emscripten-toolchain)" >> $GITHUB_OUTPUT
         id: toolchain_versions
 
       - name: Install Rust toolchain

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Set toolchain versions
         run: |
-          echo "::set-output name=rust::$(cat rust-toolchain)"
-          echo "::set-output name=emscripten::$(cat emscripten-toolchain)"
+          echo "rust=$(cat rust-toolchain)" >> $GITHUB_OUTPUT
+          echo "emscripten=$(cat emscripten-toolchain)" >> $GITHUB_OUTPUT
         id: toolchain_versions
 
       - name: Install Rust toolchain


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/