### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ development server with:
 ```sh
 rustup target add wasm32-unknown-emscripten
 npm ci
-cargo install bindgen
 . scripts/install-emscripten-toolchain.sh
 npm run dev:debug # or npm run dev:release
 ```


### PR DESCRIPTION
Remove docs that install bindgen. The bindgen CLI is no longer required as of #1029.