### PR TITLE
Add docs, safe wrappers around raw pointers, tests

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -1,0 +1,38 @@
+---
+name: Documentation
+"on":
+  push:
+    branches:
+      - trunk
+  pull_request:
+    branches:
+      - trunk
+  schedule:
+    - cron: "0 0 * * TUE"
+concurrency:
+  group: docs-${{ github.head_ref }}
+env:
+  CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+jobs:
+  rustdoc:
+    name: Build Rust API docs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs
+      RUST_BACKTRACE: 1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        uses: artichoke/setup-rust/rustdoc@v1
+
+      - name: Check docs with no default features
+        run: cargo doc --workspace --no-default-features
+
+      - name: Clean docs
+        run: cargo clean
+
+      - name: Build Documentation
+        run: cargo doc --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "playground"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "artichoke",
  "bstr",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@artichokeruby/playground",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@artichokeruby/playground",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@artichokeruby/logo": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@artichokeruby/playground",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "description": "Artichoke Ruby Wasm Playground",
   "keywords": [

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "playground"
-version = "0.11.0" # remember to bump package.json
+version = "0.12.0" # remember to bump package.json
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "MIT"
 edition = "2021"

--- a/playground/src/emscripten.rs
+++ b/playground/src/emscripten.rs
@@ -1,7 +1,14 @@
-#![cfg(target_os = "emscripten")]
+//! FFI bindings to emscripten web APIs.
 
-// taken from https://github.com/Gigoteur/PX8/blob/master/src/px8/emscripten.rs
-// taken from https://github.com/gliheng/rust-wasm/blob/d89a71f4a68101c7b4e2944973b39a2c20b21ebe/sdl2-drag/src/emscripten.rs
+// This source is adapted from https://github.com/gliheng/rust-wasm as of
+// commit d89a71f4a68101c7b4e2944973b39a2c20b21ebe.
+//
+// The file is licensed with the MIT License Copyright (c) 2017 Amadeus.
+//
+// See:
+//
+// - https://github.com/gliheng/rust-wasm/blob/d89a71f4a68101c7b4e2944973b39a2c20b21ebe/sdl2-drag/src/emscripten.rs
+// - https://github.com/gliheng/rust-wasm/blob/d89a71f4a68101c7b4e2944973b39a2c20b21ebe/LICENSE
 
 use std::cell::RefCell;
 use std::os::raw::c_int;
@@ -10,7 +17,17 @@ use std::os::raw::c_int;
 type em_callback_func = unsafe extern "C" fn();
 
 extern "C" {
+    // Set a C function as the main event loop for the calling thread.
+    //
+    // See the emscripten docs for [`emscripten_set_main_loop`][upstream-docs].
+    //
+    // # Header Declaration
+    //
+    // ```c
     // void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop)
+    // ```
+    //
+    // [upstream-docs]: https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_set_main_loop
     fn emscripten_set_main_loop(func: em_callback_func, fps: c_int, simulate_infinite_loop: c_int);
 }
 
@@ -24,6 +41,11 @@ unsafe extern "C" fn wrapper() {
     });
 }
 
+/// Set the given callback as the emscripten main loop callback.
+///
+/// See the emscripten docs on the [browser main loop].
+///
+/// [browser main loop]: https://emscripten.org/docs/porting/emscripten-runtime-environment.html#browser-main-loop
 pub fn set_main_loop_callback<F>(callback: F)
 where
     F: FnMut() + 'static,

--- a/playground/src/ffi.rs
+++ b/playground/src/ffi.rs
@@ -1,4 +1,6 @@
-use std::mem::ManuallyDrop;
+//! FFI utilities for JavaScript / Rust interop over Wasm.
+
+use std::mem::{size_of, ManuallyDrop};
 
 use crate::interpreter::Interp;
 use crate::string::Heap;
@@ -6,12 +8,47 @@ use crate::string::Heap;
 /// String heap for marshalling data between Rust and JavaScript.
 #[derive(Default, Debug, Clone)]
 pub struct State {
-    pub heap: Heap,
+    /// The string heap.
+    ///
+    /// The `extern "C"` functions in this module use this heap to allow JS and
+    /// Wasm code to pass strings back and forth across the Wasm boundary.
+    heap: Heap,
+}
+
+impl State {
+    /// Convert a boxed state into an opaque, pointer-sized value to pass to
+    /// foreign code.
+    pub fn into_raw(self: Box<Self>) -> u32 {
+        Box::into_raw(self) as u32
+    }
+
+    /// Convert an opaque, pointer-sized value back to a boxed state.
+    ///
+    /// `from_raw` operates on values returned from [`into_raw`].
+    ///
+    /// [`into_raw`]: Self::into_raw
+    ///
+    /// # Safety
+    ///
+    /// `raw` must be the address of a `Box<State>` which was returned from
+    /// `State::into_raw`. The state represented by this raw address must not
+    /// have been dropped.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the given `raw` is 0 (a null pointer).
+    pub unsafe fn from_raw(raw: u32) -> Box<Self> {
+        // ensure all `u32` can be converted to a pointer-sized value.
+        const _: () = assert!(size_of::<u32>() <= size_of::<*mut State>());
+
+        assert_ne!(raw, 0, "null pointer");
+        unsafe { Box::from_raw(raw as *mut State) }
+    }
 }
 
 #[no_mangle]
 #[must_use]
-pub extern "C" fn artichoke_web_repl_init() -> u32 {
+extern "C" fn artichoke_web_repl_init() -> u32 {
     let mut state = Box::<State>::default();
     let build = match Interp::new() {
         Ok(mut interp) => interp
@@ -21,63 +58,51 @@ pub extern "C" fn artichoke_web_repl_init() -> u32 {
     };
     println!("{build}");
     state.heap.allocate(build);
-    Box::into_raw(state) as u32
+    state.into_raw()
 }
 
 #[no_mangle]
 #[must_use]
-pub extern "C" fn artichoke_string_new(state: u32) -> u32 {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_string_new(state: u32) -> u32 {
+    let state = unsafe { State::from_raw(state) };
     let mut state = ManuallyDrop::new(state);
     state.heap.allocate(String::new())
 }
 
 #[no_mangle]
-pub extern "C" fn artichoke_string_free(state: u32, ptr: u32) {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_string_free(state: u32, ptr: u32) {
+    let state = unsafe { State::from_raw(state) };
     let mut state = ManuallyDrop::new(state);
     state.heap.free(ptr);
 }
 
 #[no_mangle]
 #[must_use]
-pub extern "C" fn artichoke_string_getlen(state: u32, ptr: u32) -> u32 {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_string_getlen(state: u32, ptr: u32) -> u32 {
+    let state = unsafe { State::from_raw(state) };
     let state = ManuallyDrop::new(state);
     state.heap.string_getlen(ptr)
 }
 
 #[no_mangle]
 #[must_use]
-pub extern "C" fn artichoke_string_getch(state: u32, ptr: u32, idx: u32) -> u8 {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_string_getch(state: u32, ptr: u32, idx: u32) -> u8 {
+    let state = unsafe { State::from_raw(state) };
     let state = ManuallyDrop::new(state);
     state.heap.string_getch(ptr, idx)
 }
 
 #[no_mangle]
-pub extern "C" fn artichoke_string_putch(state: u32, ptr: u32, ch: u8) {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_string_putch(state: u32, ptr: u32, ch: u8) {
+    let state = unsafe { State::from_raw(state) };
     let mut state = ManuallyDrop::new(state);
     state.heap.string_putch(ptr, ch);
 }
 
 #[no_mangle]
 #[must_use]
-pub extern "C" fn artichoke_eval(state: u32, ptr: u32) -> u32 {
-    assert_ne!(state, 0, "null pointer");
-
-    let state = unsafe { Box::from_raw(state as *mut State) };
+extern "C" fn artichoke_eval(state: u32, ptr: u32) -> u32 {
+    let state = unsafe { State::from_raw(state) };
     let mut state = ManuallyDrop::new(state);
     let code = state.heap.string(ptr);
 

--- a/playground/src/ffi.rs
+++ b/playground/src/ffi.rs
@@ -18,6 +18,7 @@ pub struct State {
 impl State {
     /// Convert a boxed state into an opaque, pointer-sized value to pass to
     /// foreign code.
+    #[must_use]
     pub fn into_raw(self: Box<Self>) -> u32 {
         Box::into_raw(self) as u32
     }
@@ -37,6 +38,7 @@ impl State {
     /// # Panics
     ///
     /// This function panics if the given `raw` is 0 (a null pointer).
+    #[must_use]
     pub unsafe fn from_raw(raw: u32) -> Box<Self> {
         // ensure all `u32` can be converted to a pointer-sized value.
         const _: () = assert!(size_of::<u32>() <= size_of::<*mut State>());
@@ -57,7 +59,8 @@ extern "C" fn artichoke_web_repl_init() -> u32 {
         Err(err) => err.to_string(),
     };
     println!("{build}");
-    state.heap.allocate(build);
+    let sym = state.heap.allocate(build);
+    assert_eq!(sym, 0); // assumed by TypeScript code
     state.into_raw()
 }
 

--- a/playground/src/interpreter.rs
+++ b/playground/src/interpreter.rs
@@ -1,14 +1,19 @@
-use artichoke::backend::state::output::Captured;
-use artichoke::backend::state::parser::Context;
-use artichoke::backend::value;
-use artichoke::prelude::*;
-use bstr::ByteSlice;
-use scolapasta_string_escape::format_debug_escape_into;
+//! Wrappers around [`artichoke::Artichoke`] for the playground.
+
 use std::ffi::OsStr;
 use std::fmt;
 use std::mem;
 use std::path::Path;
 use std::str;
+
+use bstr::ByteSlice;
+
+use artichoke::backend::ffi::InterpreterExtractError;
+use artichoke::backend::state::output::Captured;
+use artichoke::backend::state::parser::Context;
+use artichoke::backend::value;
+use artichoke::prelude::*;
+use scolapasta_string_escape::format_debug_escape_into;
 
 use crate::meta;
 
@@ -30,7 +35,7 @@ where
 {
     /// Coalesce stdout, stderr, and `returned_value.inspect` into an output
     /// report suitable for displaying in the playground webapp.
-    fn to_report<W>(&self, mut f: W, interp: &mut Artichoke) -> fmt::Result
+    pub fn to_report<W>(&self, mut f: W, interp: &mut Artichoke) -> fmt::Result
     where
         W: fmt::Write,
     {
@@ -78,6 +83,10 @@ where
 }
 
 /// Auto-closing Ruby interpreter.
+///
+/// See [`Artichoke`] for more details.
+///
+/// This wrapper implements [`Eval`] from artichoke-core.
 #[derive(Debug)]
 pub struct Interp(Option<Artichoke>);
 
@@ -96,10 +105,18 @@ impl Interp {
         Ok(Self(Some(interp)))
     }
 
+    /// Retrieve information about the current Artichoke build.
+    ///
+    /// See [`build_info`] for more details.
+    ///
+    /// [`build_info`]: meta::build_info
     pub fn metadata(&mut self) -> Option<String> {
         self.0.as_mut().map(meta::build_info)
     }
 
+    /// Construct a string report from the raw output of an interpreter eval.
+    ///
+    /// See [`Reporter`] for more details.
     pub fn eval_to_report(&mut self, code: &[u8]) -> Option<String> {
         let result = self.eval(code);
         if let Some(ref mut interp) = self.0 {
@@ -120,18 +137,26 @@ impl Eval for Interp {
     type Value = value::Value;
     type Error = Error;
 
+    /// Eval a byte string on and [`Artichoke`] interpreter.
+    ///
+    /// # Errors
+    ///
+    /// If an exception occurs when running the provided Ruby code, an error is
+    /// returned.
+    ///
+    /// For other possible failures, see [`Artichoke::eval`].
     fn eval(&mut self, code: &[u8]) -> Result<Self::Value, Self::Error> {
-        use artichoke::backend::ffi::InterpreterExtractError;
-
         let interp = self.0.as_mut().ok_or_else(InterpreterExtractError::new)?;
         interp.eval(code)
     }
 
+    /// This operation is not supported in the playground.
     fn eval_os_str(&mut self, _code: &OsStr) -> Result<Self::Value, Self::Error> {
         let exc = NotImplementedError::from("Evaling &OsStr is not supported on the web");
         Err(exc.into())
     }
 
+    /// This operation is not supported in the playground.
     fn eval_file(&mut self, _file: &Path) -> Result<Self::Value, Self::Error> {
         let exc =
             NotImplementedError::from("Evaling sources from files is not supported on the web");

--- a/playground/src/interpreter.rs
+++ b/playground/src/interpreter.rs
@@ -35,6 +35,10 @@ where
 {
     /// Coalesce stdout, stderr, and `returned_value.inspect` into an output
     /// report suitable for displaying in the playground webapp.
+    ///
+    /// # Errors
+    ///
+    /// If the provided writer returns an error, this function will return it.
     pub fn to_report<W>(&self, mut f: W, interp: &mut Artichoke) -> fmt::Result
     where
         W: fmt::Write,

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -3,6 +3,7 @@
 #![warn(clippy::needless_borrow)]
 #![allow(clippy::cast_lossless)]
 #![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::manual_let_else)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]

--- a/playground/src/lib.rs
+++ b/playground/src/lib.rs
@@ -7,7 +7,7 @@
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
 #![warn(rustdoc::broken_intra_doc_links)]
-// #![warn(missing_docs)]
+#![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 #![warn(rust_2018_idioms)]
@@ -15,19 +15,39 @@
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
 
+//! The Artichoke Wasm playground.
+
+#[cfg(target_os = "emscripten")]
 pub mod emscripten;
 pub mod ffi;
 pub mod interpreter;
 pub mod meta;
 pub mod string;
 
-const REPL_FILENAME: &[u8] = b"(playground)";
+/// Filename for inline code executed on the playground frontend via the embedded
+/// code editor.
+/// switch.
+///
+/// # Examples
+///
+/// ```console
+/// > __FILE__
+/// => "(playground)"
+/// ```
+pub const REPL_FILENAME: &[u8] = b"(playground)";
 
 #[cfg(test)]
-mod filename_test {
+mod test {
+    use artichoke::backend::state::parser::Context;
+
     #[test]
     fn repl_filename_does_not_contain_nul_byte() {
         let contains_nul_byte = super::REPL_FILENAME.iter().copied().any(|b| b == b'\0');
         assert!(!contains_nul_byte);
+    }
+
+    #[test]
+    fn repl_filename_context_new_unchecked_safety() {
+        Context::new(super::REPL_FILENAME).unwrap();
     }
 }

--- a/playground/src/main.rs
+++ b/playground/src/main.rs
@@ -5,14 +5,16 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::option_if_let_else)]
 #![allow(unknown_lints)]
-#![warn(broken_intra_doc_links)]
-// #![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![warn(missing_docs)]
 #![warn(missing_debug_implementations)]
 #![warn(missing_copy_implementations)]
 #![warn(rust_2018_idioms)]
 #![warn(trivial_casts, trivial_numeric_casts)]
 #![warn(unused_qualifications)]
 #![warn(variant_size_differences)]
+
+//! Entrypoint for Artichoke Wasm playground.
 
 #[cfg(target_os = "emscripten")]
 fn main() {
@@ -21,7 +23,9 @@ fn main() {
 
 #[cfg(not(target_os = "emscripten"))]
 fn main() {
-    eprintln!("The playground only supports the wasm32-unknown-emscripten target");
-    eprintln!("See the `build` script in `package.json` for a build recipe.");
+    eprintln!("The playground only supports the wasm32-unknown-emscripten target.");
+    eprintln!(
+        "See the `build` scripts in `package.json` and `scripts/build-wasm.rb` for a build recipe."
+    );
     std::process::exit(1);
 }

--- a/playground/src/meta.rs
+++ b/playground/src/meta.rs
@@ -1,5 +1,22 @@
+//! Extract information about the embedded [`Artichoke`] interpreter.
+//!
+//! [`Artichoke`]: artichoke::Artichoke
+
 use artichoke::prelude::{Value as _, *};
 
+/// Generate information about the current Artichoke build to be displayed in
+/// the playground editor UI.
+///
+/// Build info includes the values of the `RUBY_DESCRIPTION` and
+/// `ARTICHOKE_COMPILER_VERSION` constants in the embedded Artichoke interpreter.
+/// These constants include information stamped into the binary at build time.
+///
+/// # Examples
+///
+/// ```text
+/// artichoke 0.1.0-pre.0 (2023-04-25 revision 6718) [wasm32-unknown-emscripten]
+/// [rustc 1.69.0 (84c898d65 2023-04-16) on x86_64-unknown-linux-gnu]
+/// ```
 pub fn build_info(interp: &mut Artichoke) -> String {
     let mut description = interp
         .eval(b"RUBY_DESCRIPTION")

--- a/playground/src/string.rs
+++ b/playground/src/string.rs
@@ -30,6 +30,7 @@ impl Heap {
     /// let heap = Heap::new();
     /// assert_eq!(heap.capacity(), 0);
     /// ```
+    #[must_use]
     pub fn new() -> Self {
         Self {
             memory: HashMap::new(),
@@ -51,6 +52,7 @@ impl Heap {
     /// let heap = Heap::with_capacity(100);
     /// assert!(heap.capacity() >= 100);
     /// ```
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             memory: HashMap::with_capacity(capacity),
@@ -71,6 +73,7 @@ impl Heap {
     /// let heap = Heap::with_capacity(100);
     /// assert!(heap.capacity() >= 100);
     /// ```
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.memory.capacity()
     }
@@ -87,6 +90,7 @@ impl Heap {
     /// a.allocate("Wasm".to_owned());
     /// assert_eq!(a.len(), 1);
     /// ```
+    #[must_use]
     pub fn len(&self) -> usize {
         self.memory.len()
     }
@@ -103,6 +107,7 @@ impl Heap {
     /// a.allocate("Wasm".to_owned());
     /// assert!(!a.is_empty());
     /// ```
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.memory.is_empty()
     }
@@ -122,6 +127,7 @@ impl Heap {
     /// let mut a = Heap::new();
     /// let sym = a.allocate("Wasm".to_owned());
     /// ```
+    #[must_use]
     pub fn allocate(&mut self, s: String) -> u32 {
         let ptr = self.next_free;
         self.next_free += 1;

--- a/playground/src/string.rs
+++ b/playground/src/string.rs
@@ -1,5 +1,18 @@
+//! JS/Rust string interop utilities.
+
 use std::collections::HashMap;
 
+/// Persistent heap for byte strings.
+///
+/// This data structure is stored in the FFI state of a playground interpreter
+/// session. It allows JS and Wasm code to read and write strings across the
+/// JS/Wasm boundary.
+///
+/// For example, content to be eval'd on the interpreter is written to the heap
+/// by JS code and then read out of the heap by Rust code so it can be passed to
+/// an [`Artichoke`] instance.
+///
+/// [`Artichoke`]: artichoke::Artichoke
 #[derive(Debug, Clone, Default)]
 pub struct Heap {
     memory: HashMap<u32, Vec<u8>>,
@@ -7,6 +20,108 @@ pub struct Heap {
 }
 
 impl Heap {
+    /// Construct a new, empty string heap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let heap = Heap::new();
+    /// assert_eq!(heap.capacity(), 0);
+    /// ```
+    pub fn new() -> Self {
+        Self {
+            memory: HashMap::new(),
+            next_free: 0,
+        }
+    }
+
+    /// Creates an empty string heap with at least the specified capacity.
+    ///
+    /// The string heap will be able to hold at least `capacity` elements without
+    /// reallocating. This method is allowed to allocate for more elements than
+    /// `capacity`. If `capacity` is 0, the hash map will not allocate.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let heap = Heap::with_capacity(100);
+    /// assert!(heap.capacity() >= 100);
+    /// ```
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            memory: HashMap::with_capacity(capacity),
+            next_free: 0,
+        }
+    }
+
+    /// Returns the number of strings the heap can hold without reallocating.
+    ///
+    /// This number is a lower bound; the string heap might be able to hold more,
+    /// but is guaranteed to be able to hold at least this many.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let heap = Heap::with_capacity(100);
+    /// assert!(heap.capacity() >= 100);
+    /// ```
+    pub fn capacity(&self) -> usize {
+        self.memory.capacity()
+    }
+
+    /// Returns the number of strings in the heap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// assert_eq!(a.len(), 0);
+    /// a.allocate("Wasm".to_owned());
+    /// assert_eq!(a.len(), 1);
+    /// ```
+    pub fn len(&self) -> usize {
+        self.memory.len()
+    }
+
+    /// Returns `true` if the heap contains no strings.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// assert!(a.is_empty());
+    /// a.allocate("Wasm".to_owned());
+    /// assert!(!a.is_empty());
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.memory.is_empty()
+    }
+
+    /// Allocate a slot in the heap and store a UTF-8 string in it.
+    ///
+    /// This function returns a pointer-sized value which can be used to
+    /// retrieve information about the given string from the heap.
+    ///
+    /// Every call to `allocate` is guaranteed to return a unique value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// ```
     pub fn allocate(&mut self, s: String) -> u32 {
         let ptr = self.next_free;
         self.next_free += 1;
@@ -14,15 +129,60 @@ impl Heap {
         ptr
     }
 
+    /// Free the string in the heap identified by the given pointer-sized value.
+    ///
+    /// If `ptr` refers to a string not present in the heap, this function is a
+    /// no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// a.free(sym);
+    /// ```
     pub fn free(&mut self, ptr: u32) {
         self.memory.remove(&ptr);
     }
 
+    /// Retrieve the byte contents of the string in the heap identified by
+    /// `ptr`.
+    ///
+    /// If `ptr` refers to a string not present in the heap, this function will
+    /// return an empty slice.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// assert_eq!(a.string(sym), b"Wasm");
+    /// assert_eq!(a.string(u32::MAX), &[]);
+    /// ```
     #[must_use]
     pub fn string(&self, ptr: u32) -> &[u8] {
         self.memory.get(&ptr).map(Vec::as_slice).unwrap_or_default()
     }
 
+    /// Retrieve the byte length of the string in the heap identified by `ptr`.
+    ///
+    /// If `ptr` refers to a string not present in the heap, this function will
+    /// return `0`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// assert_eq!(a.string_getlen(sym), 4);
+    /// assert_eq!(a.string_getlen(u32::MAX), 0);
+    /// ```
     #[must_use]
     pub fn string_getlen(&self, ptr: u32) -> u32 {
         if let Some(s) = self.memory.get(&ptr) {
@@ -32,15 +192,56 @@ impl Heap {
         }
     }
 
+    /// Retrieve the byte at the given index of the string in the heap identified
+    /// by `ptr`.
+    ///
+    /// If `ptr` refers to a string not present in the heap, this function will
+    /// return `0`. If `idx` is out of bounds for the referenced string, this
+    /// function will return zero.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// assert_eq!(a.string_getch(sym, 0), b'W');
+    /// assert_eq!(a.string_getch(sym, 3), b'm');
+    /// assert_eq!(a.string_getch(sym, 1024), 0);
+    /// assert_eq!(a.string_getch(u32::MAX, 0), 0);
+    /// ```
     #[must_use]
     pub fn string_getch(&self, ptr: u32, idx: u32) -> u8 {
-        if let Some(s) = self.memory.get(&ptr) {
-            s[idx as usize]
+        let s = if let Some(s) = self.memory.get(&ptr) {
+            s
         } else {
-            0
-        }
+            return 0;
+        };
+        let idx = if let Ok(idx) = usize::try_from(idx) {
+            idx
+        } else {
+            return 0;
+        };
+        s.get(idx).copied().unwrap_or_default()
     }
 
+    /// Modify the string in the heap identified by `ptr` by appending a byte
+    /// to its end.
+    ///
+    /// If `ptr` refers to a string not present in the heap, this function is a
+    /// no-op.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use playground::string::Heap;
+    ///
+    /// let mut a = Heap::new();
+    /// let sym = a.allocate("Wasm".to_owned());
+    /// a.string_putch(sym, b'!');
+    /// assert_eq!(a.string(sym), b"Wasm!");
+    /// ```
     pub fn string_putch(&mut self, ptr: u32, ch: u8) {
         if let Some(s) = self.memory.get_mut(&ptr) {
             s.push(ch);


### PR DESCRIPTION
- Add a GitHub Actions workflow to test rustdoc.
- Fully document the crate.
- Add tests for REPL filename.
- Add tests and examples for string heap.
- Make inner `HashMap` field of string heap private.
- Better document provenance of emscripten bindings.
- Add links to upstream documentation for emscripten bindings.
- Add wrappers around `Box::into_raw` and `Box::from_raw`.
- Document panics and safety invariants in `ffi` module.
- Sort imports by std/3p/Artichoke 3p/crate.
- Bump playground version to v0.12.0.