### PR TITLE
Refactor emscripten main loop wrapper to be a type constructor

### DIFF
--- a/playground/src/emscripten.rs
+++ b/playground/src/emscripten.rs
@@ -91,7 +91,7 @@ unsafe extern "C" fn wrapper<F>()
 where
     F: MainLoopCallback,
 {
-    F::run_main_loop()
+    F::run_main_loop();
 }
 
 /// Set the given callback as the emscripten main loop callback.
@@ -108,12 +108,11 @@ where
 /// [browser main loop]: https://emscripten.org/docs/porting/emscripten-runtime-environment.html#browser-main-loop
 /// [docs-set]: https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_set_main_loop
 /// [docs-cancel]: https://emscripten.org/docs/api_reference/emscripten.h.html#c.emscripten_cancel_main_loop
-pub fn set_main_loop_callback<F>(callback: F)
+#[allow(clippy::needless_pass_by_value)]
+pub fn set_main_loop_callback<F>(_callback: F)
 where
     F: MainLoopCallback,
 {
-    let _ignored = callback;
-
     let had_previous_callback = MAIN_LOOP_IS_SET.with(|z| {
         let flag = &mut *z.borrow_mut();
         mem::replace(flag, true)

--- a/playground/src/main.rs
+++ b/playground/src/main.rs
@@ -18,7 +18,9 @@
 
 #[cfg(target_os = "emscripten")]
 fn main() {
-    playground::emscripten::set_main_loop_callback(|| {});
+    use playground::emscripten::{set_main_loop_callback, EmptyMainLoop};
+
+    set_main_loop_callback(EmptyMainLoop);
 }
 
 #[cfg(not(target_os = "emscripten"))]


### PR DESCRIPTION
This same pattern is used in `artichoke_backend::sys::protect`.