### PR TITLE
Fix compilation errors on latest nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
`proc-macro2` before 1.0.60 is incompatible with the latest nightly since an unstable feature conditionally used by `proc-macro2` was renamed.

Fixed with a targeted `cargo update`:

```console
$ cargo update --package proc-macro2
    Updating crates.io index
    Updating proc-macro2 v1.0.56 -> v1.0.63
```

See also:

- rust-lang/rust#113152
- dtolnay/proc-macro2#391
- https://github.com/artichoke/artichoke/pull/2619