### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Ruby][artichoke-repo] hosted at <https://artichoke.run>.
 <p align="center">
   <a href="https://artichoke.run/">
     <picture>
-      <source media="(prefers-color-scheme: dark)" src="https://artichoke.run/artichoke-playground-safari-revision-4938-dark-mode.png">
+      <source media="(prefers-color-scheme: dark)" srcset="https://artichoke.run/artichoke-playground-safari-revision-4938-dark-mode.png">
       <source media="(prefers-color-scheme: light)" srcset="https://artichoke.run/artichoke-playground-safari-revision-4938-light-mode.png">
       <img style="max-width: 400px" width="400" src="https://artichoke.run/artichoke-playground-safari-revision-4938-light-mode.png">
     </picture>

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ Ruby][artichoke-repo] hosted at <https://artichoke.run>.
 ## Try Artichoke
 
 <p align="center">
-  <a href="https://artichoke.run/#gh-light-mode-only">
-    <img style="max-width: 400px" width="400" src="https://artichoke.run/artichoke-playground-safari-revision-4938-light-mode.png">
-  </a>
-  <a href="https://artichoke.run/#gh-dark-mode-only">
-    <img style="max-width: 400px" width="400" src="https://artichoke.run/artichoke-playground-safari-revision-4938-dark-mode.png">
+  <a href="https://artichoke.run/">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" src="https://artichoke.run/artichoke-playground-safari-revision-4938-dark-mode.png">
+      <source media="(prefers-color-scheme: light)" srcset="https://artichoke.run/artichoke-playground-safari-revision-4938-light-mode.png">
+      <img style="max-width: 400px" width="400" src="https://artichoke.run/artichoke-playground-safari-revision-4938-light-mode.png">
+    </picture>
   </a>
   <br>
   <em>Artichoke Ruby Wasm Playground</em>


### PR DESCRIPTION
Update the special syntax for dark mode images in README.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to

Per the docs, the special anchor tags `#gh-dark-mode-only` and `#gh-light-mode-only` are deprecated.