### PR TITLE
Fix cargo-deny audit action

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -71,3 +71,4 @@ jobs:
           arguments: --locked --all-features
           command: check ${{ matrix.checks }}
           command-arguments: --show-stats
+          rust-version: "1.84.0"

--- a/Rakefile
+++ b/Rakefile
@@ -137,7 +137,7 @@ namespace :toolchain do
 
       workflow_files.each do |file|
         contents = File.read(file)
-        contents = contents.gsub(/(toolchain: "?)\d+\.\d+\.\d+("?)/, "\\1#{toolchain_version}\\2")
+        contents = contents.gsub(/((toolchain|rust-version): "?)\d+\.\d+\.\d+("?)/, "\\1#{toolchain_version}\\3")
 
         File.write(file, contents)
       end


### PR DESCRIPTION
by explicitly setting the toolchain. update the Rakefile tasks to also updated this action invocation.